### PR TITLE
Sort encounter orders by order number

### DIFF
--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/PacsIntegrationService.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/PacsIntegrationService.java
@@ -19,10 +19,23 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 import java.text.ParseException;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 @Component
 public class PacsIntegrationService {
+
+    static final Comparator<OpenMRSOrder> ORDER_COMP = 
+                                        new Comparator<OpenMRSOrder>() {
+            public int compare(OpenMRSOrder o1, OpenMRSOrder o2) {
+                String s1 = o1.getOrderNumber();
+                String s2 = o2.getOrderNumber();
+                if (s1 == null && s2 == null) return 0;
+                if (s1 == null) return -1;
+                if (s2 == null) return 1;
+                return o1.getOrderNumber().compareTo(o2.getOrderNumber());
+            }
+    };
 
     @Autowired
     private OpenMRSEncounterToOrderMapper openMRSEncounterToOrderMapper;
@@ -50,6 +63,7 @@ public class PacsIntegrationService {
         List<OrderType> acceptableOrderTypes = orderTypeRepository.findAll();
 
         List<OpenMRSOrder> newAcceptableTestOrders = openMRSEncounter.getAcceptableTestOrders(acceptableOrderTypes);
+        Collections.sort(newAcceptableTestOrders, ORDER_COMP);
         Collections.reverse(newAcceptableTestOrders);
         for(OpenMRSOrder openMRSOrder : newAcceptableTestOrders) {
             if(orderRepository.findByOrderUuid(openMRSOrder.getUuid()) == null) {


### PR DESCRIPTION
This is an attempt to fix a bug which generates many failed events for
duplicate worklist item. I believe the bug was happening when a single
encounter had NEW order and corresponding DISCONTINUE orders in the same
encounter, but they were not in the correct order, so that DISCONTINUE
orders were failing to apply.

Other possible solutions could have been:
1. ignore NEW orders that have their dateStopped attribute set
2. when processing orders, go through the list and remove NEW -
DISCONTINUE order pairs (using previousOrderUuid)