### PR TITLE
BAH-2122 | Adds liquibase migration to add default data into tables

### DIFF
--- a/pacs-integration-webapp/src/main/resources/db/changelog/liquibase.xml
+++ b/pacs-integration-webapp/src/main/resources/db/changelog/liquibase.xml
@@ -182,4 +182,11 @@
             <column name="comment" type="varchar(255)"/>
         </addColumn>
     </changeSet>
+    <changeSet id="PACS-20220804" author="Mohankumar">
+        <comment>Adding default entry to modality and order type</comment>
+        <sql>
+            INSERT IGNORE INTO modality VALUES(1,'DCM4CHEE','DCM4CHEE PACS','dcm4chee',2575,20000);
+            INSERT IGNORE INTO order_type VALUES(1,'Radiology Order',1);
+        </sql>
+    </changeSet>
 </databaseChangeLog>

--- a/pacs-integration-webapp/src/main/resources/db/changelog/liquibase.xml
+++ b/pacs-integration-webapp/src/main/resources/db/changelog/liquibase.xml
@@ -185,8 +185,8 @@
     <changeSet id="PACS-20220804" author="Mohankumar">
         <comment>Adding default entry to modality and order type</comment>
         <sql>
-            INSERT IGNORE INTO modality VALUES(1,'DCM4CHEE','DCM4CHEE PACS','dcm4chee',2575,20000);
-            INSERT IGNORE INTO order_type VALUES(1,'Radiology Order',1);
+            INSERT INTO modality(id,name,description,ip,port,timeout) VALUES(1,'DCM4CHEE','DCM4CHEE PACS','dcm4chee',2575,20000) ON CONFLICT(id) DO NOTHING;
+            INSERT INTO order_type(id,name,modality_id) VALUES(1,'Radiology Order',1) ON CONFLICT(id) DO NOTHING;
         </sql>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds a liquibase migration that adds default data mapping to modality and order_type tables.