### PR TITLE
BAH-2436 | Use corretto as base image and as actions JDK

### DIFF
--- a/.github/workflows/build_publish_pacs_integration.yml
+++ b/.github/workflows/build_publish_pacs_integration.yml
@@ -24,9 +24,9 @@ jobs:
           ./setArtifactVersion.sh
           rm setArtifactVersion.sh
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "corretto"
           java-version: "8"
       - name: Run Unit Tests
         run: ./mvnw --no-transfer-progress clean test

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -15,9 +15,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Java 8
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
-          distribution: "zulu"
+          distribution: "corretto"
           java-version: "8"
       - name: Run Unit Tests
         run: ./mvnw --no-transfer-progress clean test

--- a/package/docker/dcm4chee/Dockerfile
+++ b/package/docker/dcm4chee/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM amazoncorretto:8
 
 ENV DCM4CHEE_VERSION=dcm4chee-2.18.1-psql
 ENV JBOSS_VERSION=jboss-4.2.3.GA
@@ -13,7 +13,7 @@ RUN mkdir -p ${DCM4CHEE_PATH}
 RUN mkdir -p ${JBOSS_PATH}
 RUN mkdir -p ${DOWNLOAD_PATH}
 
-RUN apk add curl gettext postgresql-client
+RUN yum install -y gettext postgresql unzip nc
 
 RUN curl -L -o ${DOWNLOAD_PATH}/dcm4chee.zip "http://repo.mybahmni.org.s3.amazonaws.com/packages/build/${DCM4CHEE_VERSION}.zip"
 RUN unzip -d ${DOWNLOAD_PATH} ${DOWNLOAD_PATH}/dcm4chee.zip

--- a/package/docker/pacs-integration/Dockerfile
+++ b/package/docker/pacs-integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-alpine
+FROM amazoncorretto:8
 
 ENV SERVER_PORT=8054
 ENV BASE_DIR=/var/run/pacs-integration
@@ -8,7 +8,7 @@ ENV SERVER_OPTS="-Xms512m -Xmx1024m -XX:PermSize=256m -XX:MaxPermSize=512m"
 ENV DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend=n"
 
 # Used by envsubst command for replacing environment values at runtime
-RUN apk add gettext curl
+RUN yum install -y gettext nc
 
 ADD https://repo.mybahmni.org/packages/build/bahmni-embedded-tomcat-8.0.42.jar /opt/pacs-integration/lib/pacs-integration.jar
 COPY pacs-integration-webapp/target/pacs-integration.war /etc/pacs-integration/pacs-integration.war


### PR DESCRIPTION
Using amazoncorreto as baseimage since openjdk builds has beeen deprecated. More info [here](https://talk.openmrs.org/t/using-amazoncorretto-as-base-image-for-bahmni-docker-images/37668).

Co-authored-by: Divij Goyal [divij.g@beehyv.com](mailto:divij.g@beehyv.com)