### PR TITLE
BAH-3381 | Add script to update OpenMRS host and port for Atomfeed

### DIFF
--- a/package/docker/pacs-integration/Dockerfile
+++ b/package/docker/pacs-integration/Dockerfile
@@ -9,6 +9,7 @@ ENV DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend
 
 # Used by envsubst command for replacing environment values at runtime
 RUN yum install -y gettext nc
+RUN yum install -y postgresql
 
 ADD https://repo.mybahmni.org/packages/build/bahmni-embedded-tomcat-8.0.42.jar /opt/pacs-integration/lib/pacs-integration.jar
 COPY pacs-integration-webapp/target/pacs-integration.war /etc/pacs-integration/pacs-integration.war
@@ -19,6 +20,9 @@ RUN cd ${WAR_DIRECTORY} && jar xvf /etc/pacs-integration/pacs-integration.war
 COPY package/docker/pacs-integration/templates/atomfeed.properties.template /etc/atomfeed.properties.template
 COPY package/docker/pacs-integration/templates/application.properties.template /etc/application.properties.template
 RUN curl -o wait-for.sh 'https://raw.githubusercontent.com/eficode/wait-for/v2.2.3/wait-for'
+
+COPY package/docker/pacs-integration/scripts/update_openmrs_host_port.sh update_openmrs_host_port.sh
+RUN chmod +x update_openmrs_host_port.sh
 
 COPY package/docker/pacs-integration/scripts/start.sh start.sh
 RUN chmod +x start.sh

--- a/package/docker/pacs-integration/scripts/start.sh
+++ b/package/docker/pacs-integration/scripts/start.sh
@@ -8,6 +8,8 @@ envsubst < /etc/application.properties.template > "${WAR_DIRECTORY}"/WEB-INF/cla
 echo "Waiting for ${DB_HOST}.."
 sh wait-for.sh -t 300 "${DB_HOST}":"${DB_PORT}"
 
+./update_openmrs_host_port.sh
+
 echo "Waiting for ${OPENMRS_HOST}.."
 sh wait-for.sh -t 300 "${OPENMRS_HOST}":"${OPENMRS_PORT}"
 

--- a/package/docker/pacs-integration/scripts/update_openmrs_host_port.sh
+++ b/package/docker/pacs-integration/scripts/update_openmrs_host_port.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set +e
+
+run_sql() {
+  PGPASSWORD="${DB_PASSWORD}" psql --host="${DB_HOST}" -U "${DB_USERNAME}" -d "${DB_NAME}" -t -c "$1"
+}
+
+if [ $(run_sql "select count(*) from information_schema.tables where table_name='markers' and table_schema='public';") -gt 0 ]
+then
+    echo "Updating OpenMRS Host Port in markers and failed_events table"
+    run_sql "UPDATE markers SET feed_uri_for_last_read_entry = regexp_replace(feed_uri_for_last_read_entry, 'http://.*/openmrs', 'http://${OPENMRS_HOST}:${OPENMRS_PORT}/openmrs'),feed_uri = regexp_replace(feed_uri, 'http://.*/openmrs', 'http://${OPENMRS_HOST}:${OPENMRS_PORT}/openmrs') where feed_uri ~ 'openmrs';"
+    run_sql "UPDATE failed_events SET feed_uri = regexp_replace(feed_uri, 'http://.*/openmrs', 'http://${OPENMRS_HOST}:${OPENMRS_PORT}/openmrs') where feed_uri ~'openmrs';"
+fi


### PR DESCRIPTION
This PR adds a script to update the OpenMRS Host and Port configuration in markers and failed_events table. This scripts runs on startup of the container.