### PR TITLE
BAH-3967 | Fix. Add console log appender to log4j configuration

### DIFF
--- a/pacs-integration-webapp/src/main/resources/log4j2.xml
+++ b/pacs-integration-webapp/src/main/resources/log4j2.xml
@@ -10,10 +10,15 @@
             </Policies>
             <DefaultRolloverStrategy max="10"/>
         </RollingFile>
+
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{dd-MM-yyyy HH:mm:ss} [%-5p] %c{1} - %m%n"/>
+        </Console>
     </appenders>
     <loggers>
         <root level="WARN">
             <appenderref ref="MyRollingFile"/>
+            <appenderref ref="Console"/>
         </root>
     </loggers>
 </configuration>


### PR DESCRIPTION
This PR updates the log4j configuration to append logs to the console. This is needed in docker based installations to view the logs and send the logs to centralised logging