### PR TITLE
BAH-4295 | Upgrade dependencies to support Postgres 16

### DIFF
--- a/package/docker/pacs-integration/Dockerfile
+++ b/package/docker/pacs-integration/Dockerfile
@@ -9,7 +9,7 @@ ENV DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,address=8000,server=y,suspend
 
 # Used by envsubst command for replacing environment values at runtime
 RUN yum install -y gettext nc
-RUN yum install -y postgresql
+RUN amazon-linux-extras install -y postgresql14
 
 ADD https://repo.mybahmni.org/packages/build/bahmni-embedded-tomcat-8.0.42.jar /opt/pacs-integration/lib/pacs-integration.jar
 COPY pacs-integration-webapp/target/pacs-integration.war /etc/pacs-integration/pacs-integration.war

--- a/pacs-integration-webapp/pom.xml
+++ b/pacs-integration-webapp/pom.xml
@@ -86,7 +86,7 @@
         <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
-            <version>9.2-1003-jdbc4</version>
+            <version>42.7.8</version>
             <scope>runtime</scope>
         </dependency>
 
@@ -148,17 +148,12 @@
         <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
-            <version>3.4.0</version>
+            <version>3.10.3</version>
         </dependency>
         <dependency>
             <groupId>com.mattbertolini</groupId>
             <artifactId>liquibase-slf4j</artifactId>
-            <version>1.0.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.liquibase.ext</groupId>
-            <artifactId>liquibase-postgresql</artifactId>
-            <version>3.0</version>
+            <version>2.0.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
This PR upgrades the Postgres JDBC driver and liquibase dependencies to support Postgres 16.

**Next Steps**: The latest version of liquibase is 4.x, which requires Spring upgrade and to handled later.

JIRA: https://bahmni.atlassian.net/browse/BAH-4295