### PR TITLE
BAH-4391 | Add. Mapping for mandatory fields in Hl7 message for DCM4CHEE 5

### DIFF
--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/HL7Service.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/HL7Service.java
@@ -1,10 +1,12 @@
 package org.bahmni.module.pacsintegration.services;
 
+import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.AbstractMessage;
 import ca.uhn.hl7v2.model.DataTypeException;
 import ca.uhn.hl7v2.model.v25.group.ORM_O01_PATIENT;
 import ca.uhn.hl7v2.model.v25.message.ORM_O01;
 import ca.uhn.hl7v2.model.v25.segment.*;
+import ca.uhn.hl7v2.util.Terser;
 import org.bahmni.module.pacsintegration.atomfeed.contract.encounter.OpenMRSConceptMapping;
 import org.bahmni.module.pacsintegration.atomfeed.contract.encounter.OpenMRSOrder;
 import org.bahmni.module.pacsintegration.atomfeed.contract.encounter.OpenMRSProvider;
@@ -13,6 +15,7 @@ import org.bahmni.module.pacsintegration.exception.HL7MessageException;
 import org.bahmni.module.pacsintegration.model.Order;
 import org.bahmni.module.pacsintegration.repository.OrderRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 import java.text.DateFormat;
@@ -26,27 +29,44 @@ public class HL7Service {
     @Autowired
     private OrderRepository orderRepository;
 
+    @Autowired
+    private StudyInstanceUIDGenerator studyInstanceUIDGenerator;
+
+    @Value("${hl7.sending.application:Bahmni EMR}")
+    private String sendingApplication;
+
+    @Value("${hl7.sending.facility:Bahmni Hospital}")
+    private String sendingFacility;
+
+    @Value("${hl7.receiving.application:Bahmni PACS}")
+    private String receivingApplication;
+
+    @Value("${hl7.receiving.facility:Bahmni Hospital}")
+    private String receivingFacility;
+
+    @Value("${hl7.patient.identifier.type.code:MR}")
+    private String patientIdentifierTypeCode;
 
     public HL7Service() {
     }
 
-    public HL7Service(OrderRepository orderRepository) {
-        this.orderRepository = orderRepository;
-    }
 
     private final String NEW_ORDER = "NW";
     private final String CANCEL_ORDER = "CA";
     private final String SENDER = "BahmniEMR";
+    private final String HL7_SCHEDULED_STATUS_CODE = "SC";
+    private final String HL7_CANCELLED_STATUS_CODE = "CA";
+    private final String PATIENT_IDENTIFIER_AUTHORITY = "Bahmni EMR";
 
-    public AbstractMessage createMessage(OpenMRSOrder order, OpenMRSPatient openMRSPatient, List<OpenMRSProvider> providers) throws DataTypeException {
-        if(order.isDiscontinued()) {
+    public AbstractMessage createMessage(OpenMRSOrder order, OpenMRSPatient openMRSPatient, List<OpenMRSProvider> providers) throws HL7Exception {
+        if (order.isDiscontinued()) {
             return cancelOrderMessage(order, openMRSPatient, providers);
         } else {
             return createOrderMessage(order, openMRSPatient, providers);
         }
     }
 
-    private AbstractMessage createOrderMessage(OpenMRSOrder order, OpenMRSPatient openMRSPatient, List<OpenMRSProvider> providers) throws DataTypeException {
+    private AbstractMessage createOrderMessage(OpenMRSOrder order, OpenMRSPatient openMRSPatient, List<OpenMRSProvider> providers) throws HL7Exception {
         ORM_O01 message = new ORM_O01();
         addMessageHeader(order, message);
         addPatientDetails(message, openMRSPatient);
@@ -55,7 +75,7 @@ public class HL7Service {
         // handle ORC component
         ORC orc = message.getORDER().getORC();
         String orderNumber = order.getOrderNumber();
-        if(isSizeExceedingLimit(orderNumber)) {
+        if (isSizeExceedingLimit(orderNumber)) {
             throw new HL7MessageException("Unable to create HL7 message. Order Number size exceeds limit " + orderNumber);
         }
         orc.getQuantityTiming(0).getPriority().setValue(order.getUrgency());
@@ -63,8 +83,10 @@ public class HL7Service {
         orc.getFillerOrderNumber().getEntityIdentifier().setValue(orderNumber); //accession number - should be of length 16 bytes
         orc.getEnteredBy(0).getGivenName().setValue(SENDER);
         orc.getOrderControl().setValue(NEW_ORDER);
+        orc.getOrderStatus().setValue(HL7_SCHEDULED_STATUS_CODE);
 
         addOBRComponent(order, message);
+        addZDSSegment(orderNumber, message);
         return message;
     }
 
@@ -72,10 +94,10 @@ public class HL7Service {
         return orderNumber.getBytes().length > 16;
     }
 
-    private AbstractMessage cancelOrderMessage(OpenMRSOrder order, OpenMRSPatient openMRSPatient, List<OpenMRSProvider> providers) throws DataTypeException {
+    private AbstractMessage cancelOrderMessage(OpenMRSOrder order, OpenMRSPatient openMRSPatient, List<OpenMRSProvider> providers) throws DataTypeException, ca.uhn.hl7v2.HL7Exception {
         Order previousOrder = orderRepository.findByOrderUuid(order.getPreviousOrderUuid());
-        if(previousOrder == null) {
-            throw  new HL7MessageException("Unable to Cancel the Order. Previous order is not found" + order.getOrderNumber());
+        if (previousOrder == null) {
+            throw new HL7MessageException("Unable to Cancel the Order. Previous order is not found" + order.getOrderNumber());
         }
         ORM_O01 message = new ORM_O01();
         addMessageHeader(order, message);
@@ -85,37 +107,40 @@ public class HL7Service {
         // handle ORC component
         ORC orc = message.getORDER().getORC();
         String orderNumber = previousOrder.getOrderNumber();
-        if(isSizeExceedingLimit(order.getOrderNumber())) {
+        if (isSizeExceedingLimit(order.getOrderNumber())) {
             throw new HL7MessageException("Unable to create HL7 message. Order Number size exceeds limit" + orderNumber);
         }
         orc.getPlacerOrderNumber().getEntityIdentifier().setValue(orderNumber);
         orc.getFillerOrderNumber().getEntityIdentifier().setValue(orderNumber); //accession number - should be of length 16 bytes
         orc.getEnteredBy(0).getGivenName().setValue(SENDER);
         orc.getOrderControl().setValue(CANCEL_ORDER);
+        orc.getOrderStatus().setValue(HL7_CANCELLED_STATUS_CODE);
 
         addOBRComponent(order, message);
+        addZDSSegment(orderNumber, message);
         return message;
     }
 
-    private void addMessageHeader(OpenMRSOrder order, ORM_O01 message) throws DataTypeException {
+    private void addMessageHeader(OpenMRSOrder order, ORM_O01 message) throws HL7Exception {
         MSH msh = message.getMSH();
 
         msh.getMessageControlID().setValue(generateMessageControlID(order.getOrderNumber()));
-        populateMessageHeader(msh, new Date(), "ORM", "O01", SENDER);
+        populateMessageHeader(msh, new Date(), "ORM", "O01");
     }
 
-    private void addOBRComponent(OpenMRSOrder order, ORM_O01 message) throws DataTypeException {
+    private void addOBRComponent(OpenMRSOrder order, ORM_O01 message) throws HL7Exception {
         // handle OBR component
         OBR obr = message.getORDER().getORDER_DETAIL().getOBR();
 
         OpenMRSConceptMapping pacsConceptSource = order.getPacsConceptSource();
-        if(pacsConceptSource == null) {
+        if (pacsConceptSource == null) {
             throw new HL7MessageException("Unable to create HL7 message. Missing concept source for order" + order.getUuid());
         }
         obr.getUniversalServiceIdentifier().getIdentifier().setValue(pacsConceptSource.getCode());
         obr.getUniversalServiceIdentifier().getText().setValue(pacsConceptSource.getName());
         obr.getReasonForStudy(0).getText().setValue(order.getCommentToFulfiller());
         obr.getCollectorSComment(0).getText().setValue(order.getConcept().getName().getName());
+        obr.getPlacerField1().parse(order.getOrderNumber());
     }
 
     private void addProviderDetails(List<OpenMRSProvider> providers, ORM_O01 message) throws DataTypeException {
@@ -125,16 +150,20 @@ public class HL7Service {
         orc.getOrderingProvider(0).getIDNumber().setValue(openMRSProvider.getUuid());
     }
 
-    private void addPatientDetails(ORM_O01 message, OpenMRSPatient openMRSPatient) throws DataTypeException {
+    private void addPatientDetails(ORM_O01 message, OpenMRSPatient openMRSPatient) throws HL7Exception {
         // handle the patient PID component
         ORM_O01_PATIENT patient = message.getPATIENT();
         PID pid = patient.getPID();
         pid.getPatientIdentifierList(0).getIDNumber().setValue(openMRSPatient.getPatientId());
-        pid.getPatientName(0).getGivenName().setValue(openMRSPatient.getPatientId());
+        pid.getPatientIdentifierList(0).getIdentifierTypeCode().setValue(patientIdentifierTypeCode);
+        pid.getPatientIdentifierList(0).getAssigningAuthority().parse(PATIENT_IDENTIFIER_AUTHORITY);
+
+        pid.getPatientName(0).getGivenName().setValue(openMRSPatient.getGivenName());
+        pid.getPatientName(0).getFamilyName().getSurname().setValue(openMRSPatient.getFamilyName());
         pid.getDateTimeOfBirth().getTime().setValue(openMRSPatient.getBirthDate());
         pid.getAdministrativeSex().setValue(openMRSPatient.getGender());
 
-        message.getORDER().getORDER_DETAIL().getOBR().getPlannedPatientTransportComment(0).getText().setValue(openMRSPatient.getGivenName()+","+openMRSPatient.getFamilyName());
+        message.getORDER().getORDER_DETAIL().getOBR().getPlannedPatientTransportComment(0).getText().setValue(openMRSPatient.getGivenName() + "," + openMRSPatient.getFamilyName());
 
     }
 
@@ -142,12 +171,13 @@ public class HL7Service {
         return new SimpleDateFormat("yyyyMMddHH");
     }
 
-    private MSH populateMessageHeader(MSH msh, Date dateTime, String messageType, String triggerEvent, String sendingFacility) throws DataTypeException {
+    private MSH populateMessageHeader(MSH msh, Date dateTime, String messageType, String triggerEvent) throws HL7Exception {
         msh.getFieldSeparator().setValue("|");
         msh.getEncodingCharacters().setValue("^~\\&");
-        msh.getSendingFacility().getHd1_NamespaceID().setValue(sendingFacility);
-        msh.getSendingFacility().getUniversalID().setValue(sendingFacility);
-        msh.getSendingFacility().getNamespaceID().setValue(sendingFacility);
+        msh.getSendingApplication().parse(sendingApplication);
+        msh.getSendingFacility().parse(sendingFacility);
+        msh.getReceivingApplication().parse(receivingApplication);
+        msh.getReceivingFacility().parse(receivingFacility);
         msh.getDateTimeOfMessage().getTs1_Time().setValue(getHl7DateFormat().format(dateTime));
         msh.getMessageType().getMessageCode().setValue(messageType);
         msh.getMessageType().getTriggerEvent().setValue(triggerEvent);
@@ -161,5 +191,22 @@ public class HL7Service {
         int endAt = (orderNumber.length() < 9) ? orderNumber.length() : 9;
         return (new Date().getTime() + orderNumber.substring(4, endAt));
     }
+
+    /**
+     * Add ZDS segment for DICOM Study Instance UID (required by DCM4CHEE 5)
+     * This method stores the StudyInstanceUID that will be added to the message during encoding
+     */
+    private void addZDSSegment(String orderNumber, ORM_O01 message) {
+        try {
+            String studyInstanceUID = studyInstanceUIDGenerator.generateStudyInstanceUID(orderNumber);
+            message.addNonstandardSegment("ZDS");
+            Terser terser = new Terser(message);
+            terser.set("ZDS-1", studyInstanceUID);
+
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to attach StudyInstanceUID for order", e);
+        }
+    }
+
 
 }

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/StudyInstanceUIDGenerator.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/StudyInstanceUIDGenerator.java
@@ -1,0 +1,9 @@
+package org.bahmni.module.pacsintegration.services;
+
+import org.bahmni.module.pacsintegration.atomfeed.contract.encounter.OpenMRSOrder;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface StudyInstanceUIDGenerator {
+    String generateStudyInstanceUID(String orderNumber);
+}

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImpl.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImpl.java
@@ -1,6 +1,5 @@
 package org.bahmni.module.pacsintegration.services.impl;
 
-import org.bahmni.module.pacsintegration.atomfeed.contract.encounter.OpenMRSOrder;
 import org.bahmni.module.pacsintegration.services.StudyInstanceUIDGenerator;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImpl.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImpl.java
@@ -1,0 +1,20 @@
+package org.bahmni.module.pacsintegration.services.impl;
+
+import org.bahmni.module.pacsintegration.atomfeed.contract.encounter.OpenMRSOrder;
+import org.bahmni.module.pacsintegration.services.StudyInstanceUIDGenerator;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class StudyInstanceUIDGeneratorImpl implements StudyInstanceUIDGenerator {
+
+    @Value("${study.instance.uid.prefix:1.2.826.0.1.3680043.8.498}")
+    private String studyInstanceUIDPrefix;
+
+    @Override
+    public String generateStudyInstanceUID(String orderNumber) {
+
+        int orderHash = Math.abs(orderNumber.hashCode());
+        return studyInstanceUIDPrefix + "." + orderHash;
+    }
+}

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/atomfeed/builders/OpenMRSOrderBuilder.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/atomfeed/builders/OpenMRSOrderBuilder.java
@@ -49,5 +49,13 @@ public class OpenMRSOrderBuilder {
         return this;
     }
 
+    public OpenMRSOrderBuilder withUrgency(String urgency) {
+        openMRSOrder.setUrgency(urgency);
+        return this;
+    }
 
+    public OpenMRSOrderBuilder withCommentToFulfiller(String comment) {
+        openMRSOrder.setCommentToFulfiller(comment);
+        return this;
+    }
 }

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/HL7ServiceTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/HL7ServiceTest.java
@@ -1,7 +1,12 @@
 package org.bahmni.module.pacsintegration.services;
 
-import ca.uhn.hl7v2.model.DataTypeException;
+import ca.uhn.hl7v2.HL7Exception;
 import ca.uhn.hl7v2.model.v25.message.ORM_O01;
+import ca.uhn.hl7v2.model.v25.segment.MSH;
+import ca.uhn.hl7v2.model.v25.segment.OBR;
+import ca.uhn.hl7v2.model.v25.segment.ORC;
+import ca.uhn.hl7v2.model.v25.segment.PID;
+import ca.uhn.hl7v2.util.Terser;
 import junit.framework.Assert;
 import org.bahmni.module.pacsintegration.atomfeed.builders.OpenMRSConceptBuilder;
 import org.bahmni.module.pacsintegration.atomfeed.builders.OpenMRSOrderBuilder;
@@ -14,24 +19,45 @@ import org.bahmni.module.pacsintegration.atomfeed.contract.patient.OpenMRSPatien
 import org.bahmni.module.pacsintegration.exception.HL7MessageException;
 import org.bahmni.module.pacsintegration.model.Order;
 import org.bahmni.module.pacsintegration.repository.OrderRepository;
+import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.initMocks;
 
+@RunWith(MockitoJUnitRunner.class)
 public class HL7ServiceTest {
 
     @Mock
     private OrderRepository orderRepository;
 
+    @Mock
+    private StudyInstanceUIDGenerator studyInstanceUIDGenerator;
+
+    @InjectMocks
+    private HL7Service hl7Service;
+
+    @Before
+    public void setUp() {
+        // Set configurable properties from test application.properties values
+        ReflectionTestUtils.setField(hl7Service, "sendingApplication", "Test EMR");
+        ReflectionTestUtils.setField(hl7Service, "sendingFacility", "Test Hospital");
+        ReflectionTestUtils.setField(hl7Service, "receivingApplication", "Test PACS");
+        ReflectionTestUtils.setField(hl7Service, "receivingFacility", "Test Facility");
+        ReflectionTestUtils.setField(hl7Service, "patientIdentifierTypeCode", "MR");
+    }
+
     @Test
     public void testGenerateMessageControlIDShouldBeLessThan20Characters() throws Exception {
-        HL7Service hl7Service = new HL7Service();
         String messageControlID = hl7Service.generateMessageControlID("ORD-35");
 
         Assert.assertTrue("HL7 Message control id should be less than 20 characters", messageControlID.length() <= 20);
@@ -39,29 +65,30 @@ public class HL7ServiceTest {
 
     @Test
     public void testGenerateMessageControlIDShouldBeLessThan20CharactersForLongOrderNumbers() throws Exception {
-        HL7Service hl7Service = new HL7Service();
         String messageControlID = hl7Service.generateMessageControlID("ORD-3550000");
 
         Assert.assertTrue("HL7 Message control id should be less than 20 characters", messageControlID.length() <= 20);
     }
 
     @Test(expected=HL7MessageException.class)
-    public void testShouldThrowExceptionWhenThereIsNoPACSConceptSource() throws DataTypeException {
+    public void testShouldThrowExceptionWhenThereIsNoPACSConceptSource() throws HL7Exception {
         OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource("some source", "123")).build();
         OpenMRSPatient patient = new OpenMRSPatient();
         List<OpenMRSProvider> providers = getProvidersData();
 
-        HL7Service hl7Service = new HL7Service();
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
         hl7Service.createMessage(order, patient, providers);
     }
 
     @Test
-    public void testShouldCreateHL7Message() throws DataTypeException {
+    public void testShouldCreateHL7Message() throws HL7Exception {
         OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
         OpenMRSPatient patient = new OpenMRSPatient();
         List<OpenMRSProvider> providers = getProvidersData();
 
-        HL7Service hl7Service = new HL7Service();
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
         ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
 
         Assert.assertNotNull(hl7Message);
@@ -70,14 +97,12 @@ public class HL7ServiceTest {
 
     @Test
     public void testShouldCreateCancelOrderMessageForDiscontinuedOrder() throws Exception {
-        initMocks(this);
         Order previousOrder = new Order(111, null, "someOrderUuid", "someTestName", "someTestUuid", null, "ORD-111", "Comment");
         OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-222").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).withPreviousOrderUuid(previousOrder.getOrderUuid()).withDiscontinued().build();
         OpenMRSPatient patient = new OpenMRSPatient();
         List<OpenMRSProvider> providers = getProvidersData();
         when(orderRepository.findByOrderUuid(order.getPreviousOrderUuid())).thenReturn(previousOrder);
 
-        HL7Service hl7Service = new HL7Service(orderRepository);
         ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
 
         Assert.assertNotNull(hl7Message);
@@ -87,15 +112,296 @@ public class HL7ServiceTest {
 
     @Test(expected = HL7MessageException.class)
     public void testShouldThrowExceptionForOrderNumberWithSizeExceedingLimit() throws Exception {
-
         OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-11189067898900").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
         OpenMRSPatient patient = new OpenMRSPatient();
         List<OpenMRSProvider> providers = getProvidersData();
 
-        HL7Service hl7Service = new HL7Service();
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
         hl7Service.createMessage(order, patient, providers);
     }
 
+    @Test
+    public void testShouldSetConfigurableMessageHeaderFields() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        MSH msh = hl7Message.getMSH();
+        assertEquals("Test EMR", msh.getSendingApplication().encode());
+        assertEquals("Test Hospital", msh.getSendingFacility().encode());
+        assertEquals("Test PACS", msh.getReceivingApplication().encode());
+        assertEquals("Test Facility", msh.getReceivingFacility().encode());
+    }
+
+    @Test
+    public void testShouldSetPatientIdentifierTypeCode() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = createPatient("PAT-001", "John", "Doe", "M");
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        PID pid = hl7Message.getPATIENT().getPID();
+        assertEquals("MR", pid.getPatientIdentifierList(0).getIdentifierTypeCode().getValue());
+    }
+
+    @Test
+    public void testShouldSetOrderUrgency() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder()
+                .withOrderNumber("ORD-111")
+                .withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123"))
+                .withUrgency("STAT")
+                .build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        ORC orc = hl7Message.getORDER().getORC();
+        assertEquals("STAT", orc.getQuantityTiming(0).getPriority().getValue());
+    }
+
+    @Test
+    public void testShouldSetOrderStatusToScheduled() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        ORC orc = hl7Message.getORDER().getORC();
+        assertEquals("SC", orc.getOrderStatus().getValue());
+    }
+
+    @Test
+    public void testShouldSetReasonForStudyFromCommentToFulfiller() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder()
+                .withOrderNumber("ORD-111")
+                .withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123"))
+                .withCommentToFulfiller("Patient has chest pain")
+                .build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        OBR obr = hl7Message.getORDER().getORDER_DETAIL().getOBR();
+        assertEquals("Patient has chest pain", obr.getReasonForStudy(0).getText().getValue());
+    }
+
+    @Test
+    public void testShouldSetCollectorCommentFromConceptName() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder()
+                .withOrderNumber("ORD-111")
+                .withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "CR001"))
+                .build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        OBR obr = hl7Message.getORDER().getORDER_DETAIL().getOBR();
+        assertEquals("CR001", obr.getCollectorSComment(0).getText().getValue());
+    }
+
+    @Test
+    public void testShouldSetPlannedPatientTransportCommentWithPatientName() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = createPatient("PAT-001", "John", "Doe", "M");
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        OBR obr = hl7Message.getORDER().getORDER_DETAIL().getOBR();
+        assertEquals("John,Doe", obr.getPlannedPatientTransportComment(0).getText().getValue());
+    }
+
+    @Test
+    public void testShouldAddZDSSegmentWithStudyInstanceUID() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        String expectedStudyInstanceUID = "1.2.826.0.1.3680043.8.498.12345.67890";
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn(expectedStudyInstanceUID);
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        Terser terser = new Terser(hl7Message);
+        String actualStudyInstanceUID = terser.get("ZDS-1");
+        assertEquals(expectedStudyInstanceUID, actualStudyInstanceUID);
+    }
+
+    @Test
+    public void testShouldSetPatientDetailsCorrectly() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = createPatient("PAT-001", "John", "Doe", "M");
+        patient.setBirthDate(new Date());
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        PID pid = hl7Message.getPATIENT().getPID();
+        assertEquals("PAT-001", pid.getPatientIdentifierList(0).getIDNumber().getValue());
+        assertEquals("John", pid.getPatientName(0).getGivenName().getValue());
+        assertEquals("Doe", pid.getPatientName(0).getFamilyName().getSurname().getValue());
+        assertEquals("M", pid.getAdministrativeSex().getValue());
+        assertEquals("Bahmni EMR", pid.getPatientIdentifierList(0).getAssigningAuthority().encode());
+    }
+
+    @Test
+    public void testShouldSetProviderDetailsCorrectly() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = new ArrayList<OpenMRSProvider>();
+        providers.add(new OpenMRSProvider("provider-uuid-123", "Dr. Smith"));
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        ORC orc = hl7Message.getORDER().getORC();
+        assertEquals("Dr. Smith", orc.getOrderingProvider(0).getGivenName().getValue());
+        assertEquals("provider-uuid-123", orc.getOrderingProvider(0).getIDNumber().getValue());
+    }
+
+    @Test
+    public void testShouldSetUniversalServiceIdentifierFromPacsConceptSource() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder()
+                .withOrderNumber("ORD-111")
+                .withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "CR001"))
+                .build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        OBR obr = hl7Message.getORDER().getORDER_DETAIL().getOBR();
+        assertEquals("CR001", obr.getUniversalServiceIdentifier().getIdentifier().getValue());
+        assertEquals("CR001", obr.getUniversalServiceIdentifier().getText().getValue());
+    }
+
+    @Test
+    public void testCancelOrderShouldAlsoHaveZDSSegment() throws HL7Exception {
+        Order previousOrder = new Order(111, null, "someOrderUuid", "someTestName", "someTestUuid", null, "ORD-111", "Comment");
+        OpenMRSOrder order = new OpenMRSOrderBuilder()
+                .withOrderNumber("ORD-222")
+                .withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123"))
+                .withPreviousOrderUuid(previousOrder.getOrderUuid())
+                .withDiscontinued()
+                .build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+        when(orderRepository.findByOrderUuid(order.getPreviousOrderUuid())).thenReturn(previousOrder);
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(previousOrder.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        Terser terser = new Terser(hl7Message);
+        try {
+            String zdsValue = terser.get("ZDS-1");
+            assertNotNull("ZDS segment should not be present in cancel order message", zdsValue);
+        } catch (HL7Exception e) {
+            // Expected - ZDS segment doesn't exist
+            assertTrue(e.getMessage().contains("ZDS") || e.getMessage().contains("Can't find"));
+        }
+    }
+
+    @Test
+    public void testShouldSetMessageTypeAndTriggerEvent() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        MSH msh = hl7Message.getMSH();
+        assertEquals("ORM", msh.getMessageType().getMessageCode().getValue());
+        assertEquals("O01", msh.getMessageType().getTriggerEvent().getValue());
+        assertEquals("2.5", msh.getVersionID().getVersionID().getValue());
+        assertEquals("P", msh.getProcessingID().getProcessingID().getValue());
+    }
+
+    @Test
+    public void testShouldSetPlacerAndFillerOrderNumber() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        ORC orc = hl7Message.getORDER().getORC();
+        assertEquals("ORD-111", orc.getPlacerOrderNumber().getEntityIdentifier().getValue());
+        assertEquals("ORD-111", orc.getFillerOrderNumber().getEntityIdentifier().getValue());
+        assertEquals("BahmniEMR", orc.getEnteredBy(0).getGivenName().getValue());
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testShouldThrowExceptionWhenStudyInstanceUIDGeneratorFails() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenThrow(new RuntimeException("UID generation failed"));
+
+        hl7Service.createMessage(order, patient, providers);
+    }
+
+    @Test(expected = HL7MessageException.class)
+    public void testShouldThrowExceptionWhenPreviousOrderNotFoundForCancelOrder() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder()
+                .withOrderNumber("ORD-222")
+                .withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123"))
+                .withPreviousOrderUuid("non-existent-uuid")
+                .withDiscontinued()
+                .build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+        when(orderRepository.findByOrderUuid("non-existent-uuid")).thenReturn(null);
+
+        hl7Service.createMessage(order, patient, providers);
+    }
+
+    @Test
+    public void testShouldAddOrderNumberToOBRPlacerField1() throws HL7Exception {
+        OpenMRSOrder order = new OpenMRSOrderBuilder().withOrderNumber("ORD-111").withConcept(buildConceptWithSource(Constants.PACS_CONCEPT_SOURCE_NAME, "123")).build();
+        OpenMRSPatient patient = new OpenMRSPatient();
+        List<OpenMRSProvider> providers = getProvidersData();
+
+        when(studyInstanceUIDGenerator.generateStudyInstanceUID(order.getOrderNumber())).thenReturn("1.2.3.4.5");
+
+        ORM_O01 hl7Message = (ORM_O01) hl7Service.createMessage(order, patient, providers);
+
+        OBR obr = hl7Message.getORDER().getORDER_DETAIL().getOBR();
+        assertEquals("ORD-111", obr.getPlacerField1().getValue());
+    }
 
     private OpenMRSConcept buildConceptWithSource(String conceptSourceName, String pacsCode) {
         final OpenMRSConceptMapping mapping = new OpenMRSConceptMapping();
@@ -109,5 +415,14 @@ public class HL7ServiceTest {
         List<OpenMRSProvider> providers = new ArrayList<OpenMRSProvider>();
         providers.add(new OpenMRSProvider());
         return providers;
+    }
+
+    private OpenMRSPatient createPatient(String patientId, String givenName, String familyName, String gender) {
+        OpenMRSPatient patient = new OpenMRSPatient();
+        patient.setPatientId(patientId);
+        patient.setGivenName(givenName);
+        patient.setFamilyName(familyName);
+        patient.setGender(gender);
+        return patient;
     }
 }

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImplTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImplTest.java
@@ -1,0 +1,36 @@
+package org.bahmni.module.pacsintegration.services.impl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.junit.Assert.*;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StudyInstanceUIDGeneratorImplTest {
+
+    @InjectMocks
+    private StudyInstanceUIDGeneratorImpl studyInstanceUIDGenerator;
+
+    private static final String DEFAULT_PREFIX = "1.2.826.0.1.3680043.8.498";
+
+    @Before
+    public void setUp() {
+        ReflectionTestUtils.setField(studyInstanceUIDGenerator, "studyInstanceUIDPrefix", DEFAULT_PREFIX);
+    }
+
+    @Test
+    public void shouldGenerateStudyInstanceUIDWithPrefixandOrderNumberHash() {
+        String orderNumber = "ORD-123";
+
+        String result = studyInstanceUIDGenerator.generateStudyInstanceUID(orderNumber);
+
+        String expectedUid = DEFAULT_PREFIX + "." + Math.abs(orderNumber.hashCode());
+
+        assertNotNull(result);
+        assertEquals(expectedUid, result);
+    }
+}

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImplTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/StudyInstanceUIDGeneratorImplTest.java
@@ -33,4 +33,21 @@ public class StudyInstanceUIDGeneratorImplTest {
         assertNotNull(result);
         assertEquals(expectedUid, result);
     }
+
+    @Test
+    public void shouldGenerateDifferentStudyInstanceUIDsForDifferentOrderNumbers() {
+        String orderNumber1 = "ORD-123";
+        String orderNumber2 = "ORD-456";
+        String uid1 = studyInstanceUIDGenerator.generateStudyInstanceUID(orderNumber1);
+        String uid2 = studyInstanceUIDGenerator.generateStudyInstanceUID(orderNumber2);
+        assertNotSame(uid1, uid2);
+    }
+
+    @Test
+    public void shouldGenerateSameStudyInstanceUIDForSameOrderNumber() {
+        String orderNumber = "ORD-123";
+        String uid1 = studyInstanceUIDGenerator.generateStudyInstanceUID(orderNumber);
+        String uid2 = studyInstanceUIDGenerator.generateStudyInstanceUID(orderNumber);
+        assertEquals(uid1, uid2);
+    }
 }

--- a/pacs-integration-webapp/src/test/resources/application.properties
+++ b/pacs-integration-webapp/src/test/resources/application.properties
@@ -13,3 +13,11 @@ server.port=9081
 liquibase.change-log=classpath:db/changelog/liquibase.xml
 
 enable.scheduling=false
+
+# HL7 Configuration for tests
+hl7.sending.application=Test EMR
+hl7.sending.facility=Test Hospital
+hl7.receiving.application=Test PACS
+hl7.receiving.facility=Test Facility
+hl7.patient.identifier.type.code=MR
+study.instance.uid.prefix=1.2.826.0.1.3680043.8.498


### PR DESCRIPTION
This PR adds the mandatory mappings that are required by DCM4CHEE 5 to receive and process HL7 ORM Messages and convert them to DICOM MWL.

Following are the changes:
### Message Header 
1. Added Sending Applicaton --> Can be overriden by setting environment varibale HL7_SENDING_APPLICATION
2. Added Sending Facility --> Can be overriden by setting environement variable HL7_SENDING_FACILITY. This will show as Institution Name in DICOM MWL
3. Added Receiving Applicaton --> Can be overriden by setting environment varibale HL7_RECEIVING_APPLICATION
4. Added Receving Facility --> Can be overriden by setting environement variable HL7_RECEIVING_FACILITY. This will show as Institution Name in DICOM MWL

### Patient Demographics
1. Set Identifier type code as `MR`. Can be overriden by HL7_PATIENT_IDENTIFIR_TYPE_CODE
2. Added assigning authority for identifier
3. Set names in correct fields

### ORC
Adds custom ZDS block to generate and set StudyInstanceUID.

### OBR
Adds Placer Field 1 with Order Number. Shows as Accession Number in DCM4CHEE


This change is backward compatiblw with dcm4chee 2.x also, since these mappings are part of orm2dcm.xsl which is not needed for now

#### DCM4CHEE 2.5.x
<img width="1720" height="867" alt="Screenshot 2025-11-27 at 12 06 22 AM" src="https://github.com/user-attachments/assets/9db53149-f7d7-48b9-a613-86ea1ce347fe" />

### DCM4CHEE 5.33.1
 <img width="1681" height="511" alt="Screenshot 2025-11-27 at 12 07 35 AM" src="https://github.com/user-attachments/assets/3c60dbe4-73e2-4fd5-a2b2-3156749d7f23" />|