### PR TITLE
BAH-4349 - Logging Configuration Fixes

### DIFF
--- a/pacs-integration-webapp/pom.xml
+++ b/pacs-integration-webapp/pom.xml
@@ -80,10 +80,22 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-actuator</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
@@ -160,6 +172,12 @@
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
             <version>3.10.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.mattbertolini</groupId>

--- a/pacs-integration-webapp/src/main/resources/log4j2.xml
+++ b/pacs-integration-webapp/src/main/resources/log4j2.xml
@@ -16,7 +16,7 @@
         </Console>
     </appenders>
     <loggers>
-        <root level="WARN">
+        <root level="INFO">
             <appenderref ref="MyRollingFile"/>
             <appenderref ref="Console"/>
         </root>


### PR DESCRIPTION
**JIRA** → [BAH-4349](https://bahmni.atlassian.net/browse/BAH-4349)


## Overview
This PR addresses logging configuration issues by resolving dependency conflicts and adjusting log levels for better visibility of application behavior.

## Changes

### 1. Exclude Logback Dependencies to Avoid Conflicts

Added exclusions for `logback-classic` from multiple Spring and Liquibase dependencies to prevent conflicts with the Log4j2 logging framework currently in use:

- **spring-boot-starter-data-jpa**: Excluded logback-classic
- **spring-boot-starter-actuator**: Excluded logback-classic  
- **liquibase-core**: Excluded logback-classic

**Rationale:** Spring Boot by default includes Logback as its logging implementation. Since this project uses Log4j2, excluding Logback prevents classpath conflicts and ensures consistent logging behavior throughout the application.

### 2. Enable INFO Log Level

Changed the root logger level from `WARN` to `INFO`:

**Rationale:** INFO level logging provides better visibility into application behavior, making it easier to troubleshoot issues and monitor application operations without overwhelming the logs with DEBUG-level details.


## Impact
- **Logging Framework:** Ensures Log4j2 is the sole logging implementation, preventing conflicts
- **Observability:** Enhanced logging output for better debugging and monitoring
- **Dependency Management:** Cleaner dependency tree without conflicting logging implementations
