### PR TITLE
BAH-4371 | Add. OHIF Docker Image Build Workflow

### DIFF
--- a/.github/workflows/build_publish_ohif.yml
+++ b/.github/workflows/build_publish_ohif.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout OHIF Viewers Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: OHIF/Viewers
           ref: ${{ inputs.ohif_version }}
@@ -31,7 +31,7 @@ jobs:
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
 
       - name: Docker Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/build_publish_ohif.yml
+++ b/.github/workflows/build_publish_ohif.yml
@@ -1,0 +1,44 @@
+name: Build and Publish OHIF
+on:
+  workflow_dispatch:
+    inputs:
+      ohif_version:
+        description: 'OHIF Viewers version tag (e.g. v3.8.0)'
+        required: true
+        type: string
+
+jobs:
+  build-publish-docker:
+    name: Build & Publish OHIF Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout OHIF Viewers Repository
+        uses: actions/checkout@v4
+        with:
+          repository: OHIF/Viewers
+          ref: ${{ inputs.ohif_version }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Docker Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          file: ./Dockerfile
+          build-args: |
+            PUBLIC_URL=/ohif/
+          push: true
+          tags: |
+            bahmni/ohif:${{ inputs.ohif_version }}
+            bahmni/ohif:latest


### PR DESCRIPTION
JIRA -> [BAH-4371](https://bahmni.atlassian.net/browse/BAH-4371)

- Trigger: Manual (`workflow_dispatch`)
- Input: OHIF version tag (e.g., `v3.8.0`, `v3.9.0`)
- Build Argument: `PUBLIC_URL=/ohif/`
- Architectures: `linux/amd64`, `linux/arm64`
- Image Tags: `bahmni/ohif:<version>`, `bahmni/ohif:latest`