### PR TITLE
BAH-4661 - Update Imaging Study Completion DateTime with Study Acquisition DateTime

### DIFF
--- a/package/docker/pacs-integration/templates/application.properties.template
+++ b/package/docker/pacs-integration/templates/application.properties.template
@@ -14,3 +14,9 @@ liquibase.change-log=classpath:db/changelog/liquibase.xml
 enable.scheduling=true
 
 create.imagingstudy.enabled=${CREATE_IMAGING_STUDY_ENABLED:false}
+
+# DCM4CHEE Configuration
+dcm4chee.base.url=${DCM4CHEE_BASE_URL:http://dcm4chee5:8080}
+dcm4chee.aet=${DCM4CHEE_AET:DCM4CHEE}
+dcm4chee.connection.timeout=${DCM4CHEE_CONNECTION_TIMEOUT:10000}
+dcm4chee.read.timeout=${DCM4CHEE_READ_TIMEOUT:10000}

--- a/package/docker/pacs-integration/templates/application.properties.template
+++ b/package/docker/pacs-integration/templates/application.properties.template
@@ -16,7 +16,7 @@ enable.scheduling=true
 create.imagingstudy.enabled=${CREATE_IMAGING_STUDY_ENABLED:false}
 
 # DCM4CHEE Configuration
-dcm4chee.base.url=${DCM4CHEE_BASE_URL:http://dcm4chee5:8080}
+dcm4chee.base.url=${DCM4CHEE_BASE_URL}
 dcm4chee.aet=${DCM4CHEE_AET:DCM4CHEE}
 dcm4chee.connection.timeout=${DCM4CHEE_CONNECTION_TIMEOUT:10000}
 dcm4chee.read.timeout=${DCM4CHEE_READ_TIMEOUT:10000}

--- a/pacs-integration-webapp/pom.xml
+++ b/pacs-integration-webapp/pom.xml
@@ -62,7 +62,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <atomfeed.version>1.10.1</atomfeed.version>
         <hapi-base.version>2.2</hapi-base.version>
-        <web-clients.version>1.1.0-SNAPSHOT</web-clients.version>
+        <web-clients.version>1.1.0</web-clients.version>
         <log4j.version>2.17.1</log4j.version>
     </properties>
 

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/client/Dcm4CheeConnectionDetails.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/client/Dcm4CheeConnectionDetails.java
@@ -1,0 +1,22 @@
+package org.bahmni.module.pacsintegration.client;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+
+@Component
+public class Dcm4CheeConnectionDetails {
+    @Value("${dcm4chee.base.url}")
+    private static String dcm4cheeBaseUrl;
+
+    @Value("${dcm4chee.connection.timeout}")
+    private static int connectTimeoutInMilliseconds;
+
+    @Value("${dcm4chee.read.timeout}")
+    private static int readTimeoutInMilliseconds;
+
+
+    public static org.bahmni.webclients.ConnectionDetails get() {
+        return new org.bahmni.webclients.ConnectionDetails(dcm4cheeBaseUrl, null, null, connectTimeoutInMilliseconds, readTimeoutInMilliseconds);
+    }
+}

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/client/HttpClientFactory.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/client/HttpClientFactory.java
@@ -1,0 +1,10 @@
+package org.bahmni.module.pacsintegration.client;
+
+import org.bahmni.webclients.HttpClient;
+
+public class HttpClientFactory {
+
+    public static HttpClient getDcm4CheeClient() {
+        return new HttpClient(Dcm4CheeConnectionDetails.get());
+    }
+}

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/dto/DicomMetadataDTO.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/dto/DicomMetadataDTO.java
@@ -1,0 +1,67 @@
+package org.bahmni.module.pacsintegration.dto;
+
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Setter
+@Getter
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DicomMetadataDTO {
+
+    public static final String AQUISITION_DATE_TAG = "00080022";
+    public static final String AQUISITION_TIME_TAG = "00080032";
+    private Map<String, DicomField> metadata = new HashMap<>();
+
+    public DicomMetadataDTO() {
+    }
+
+    @JsonAnySetter
+    public void setDicomTag(String tagName, DicomField tagValue) {
+        this.metadata.put(tagName, tagValue);
+    }
+
+    public String getAcquisitionDate() {
+        return getFirstValue(AQUISITION_DATE_TAG);
+    }
+
+    public String getAcquisitionTime() {
+        return getFirstValue(AQUISITION_TIME_TAG);
+    }
+
+    private String getFirstValue(String tag) {
+        if (metadata == null) {
+            return null;
+        }
+        DicomField field = metadata.get(tag);
+        if (field == null || field.getValue() == null || field.getValue().length == 0) {
+            return null;
+        }
+        return field.getValue()[0].toString();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class DicomField {
+        @Getter
+        @Setter
+        private String vr;
+        private Object[] Value;
+
+        public DicomField() {}
+
+        @JsonProperty("Value")
+        public Object[] getValue() {
+            return Value;
+        }
+
+        @JsonProperty("Value")
+        public void setValue(Object[] value) {
+            Value = value;
+        }
+    }
+}

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/dto/DicomMetadataDTO.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/dto/DicomMetadataDTO.java
@@ -16,6 +16,8 @@ public class DicomMetadataDTO {
 
     public static final String AQUISITION_DATE_TAG = "00080022";
     public static final String AQUISITION_TIME_TAG = "00080032";
+    public static final String AQUISITION_DATETIME_WITH_OFFSET_TAG = "0008002A";
+    public static final String TIMEZONE_OFFSET_FROM_UTC_TAG = "00080201";
     private Map<String, DicomField> metadata = new HashMap<>();
 
     public DicomMetadataDTO() {
@@ -32,6 +34,14 @@ public class DicomMetadataDTO {
 
     public String getAcquisitionTime() {
         return getFirstValue(AQUISITION_TIME_TAG);
+    }
+
+    public String getAcquisitionDateTime() {
+        return getFirstValue(AQUISITION_DATETIME_WITH_OFFSET_TAG);
+    }
+
+    public String getTimezoneOffsetFromUTC() {
+        return getFirstValue(TIMEZONE_OFFSET_FROM_UTC_TAG);
     }
 
     private String getFirstValue(String tag) {

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/Dcm4CheeService.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/Dcm4CheeService.java
@@ -25,6 +25,7 @@ public class Dcm4CheeService {
 
     public DicomMetadataDTO[] fetchStudyMetadata(String studyInstanceUID) throws IOException {
         if (StringUtils.isBlank(dcm4cheeBaseUrl)) {
+            logger.info("dcm4cheeBaseUrl is not configured, Skipping fetchStudyMetadata api call");
             return null;
         }
         HttpClient webClient = HttpClientFactory.getDcm4CheeClient();

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/Dcm4CheeService.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/Dcm4CheeService.java
@@ -1,0 +1,36 @@
+package org.bahmni.module.pacsintegration.services;
+
+import org.bahmni.module.pacsintegration.client.HttpClientFactory;
+import org.bahmni.module.pacsintegration.dto.DicomMetadataDTO;
+import org.bahmni.webclients.HttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class Dcm4CheeService {
+
+    private static final Logger logger = LoggerFactory.getLogger(Dcm4CheeService.class);
+    private static final String METADATA_URL_PATTERN = "%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata";
+
+    @Value("${dcm4chee.base.url}")
+    private String dcm4cheeBaseUrl;
+
+    @Value("${dcm4chee.aet}")
+    private String dcm4cheeAet;
+
+    public DicomMetadataDTO[] fetchStudyMetadata(String studyInstanceUID) throws IOException {
+        HttpClient webClient = HttpClientFactory.getDcm4CheeClient();
+        String url = buildMetadataUrl(studyInstanceUID);
+        logger.debug("Calling DCM4CHEE metadata API: {}", url);
+        return webClient.get(url, DicomMetadataDTO[].class);
+    }
+
+    private String buildMetadataUrl(String studyInstanceUID) {
+        return String.format(METADATA_URL_PATTERN,
+                dcm4cheeBaseUrl, dcm4cheeAet, studyInstanceUID);
+    }
+}

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/Dcm4CheeService.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/Dcm4CheeService.java
@@ -1,5 +1,6 @@
 package org.bahmni.module.pacsintegration.services;
 
+import org.apache.commons.lang.StringUtils;
 import org.bahmni.module.pacsintegration.client.HttpClientFactory;
 import org.bahmni.module.pacsintegration.dto.DicomMetadataDTO;
 import org.bahmni.webclients.HttpClient;
@@ -23,6 +24,9 @@ public class Dcm4CheeService {
     private String dcm4cheeAet;
 
     public DicomMetadataDTO[] fetchStudyMetadata(String studyInstanceUID) throws IOException {
+        if (StringUtils.isBlank(dcm4cheeBaseUrl)) {
+            return null;
+        }
         HttpClient webClient = HttpClientFactory.getDcm4CheeClient();
         String url = buildMetadataUrl(studyInstanceUID);
         logger.debug("Calling DCM4CHEE metadata API: {}", url);

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImpl.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImpl.java
@@ -104,18 +104,32 @@ public class ImagingStudyServiceImpl implements ImagingStudyService {
                 studyInstanceUID, imagingStudyUuid);
     }
 
-    private static Date getStudyDateTime(String studyInstanceUID, DicomMetadataDTO[] metadataArray) throws IOException {
+    private static Date getStudyDateTime(String studyInstanceUID, DicomMetadataDTO[] metadataArray) {
         if (metadataArray == null || metadataArray.length == 0) {
             return null;
         }
 
         DicomMetadataDTO metadata = metadataArray[0];
-
+        String acquisitionDateTime = metadata.getAcquisitionDateTime();
         String acquisitionDate = metadata.getAcquisitionDate();
         String acquisitionTime = metadata.getAcquisitionTime();
+        String utcOffset = metadata.getTimezoneOffsetFromUTC();
 
-        logger.info("Extracted acquisition date: {}, time: {}, for study {}", acquisitionDate, acquisitionTime, studyInstanceUID);
-        return DateUtils.combineDicomDateTime(acquisitionDate, acquisitionTime);
+        if (StringUtils.isNotBlank(acquisitionDateTime)) {
+            logger.info("Using acquisition date time(0008002A) as : {} for study {}", acquisitionDateTime, studyInstanceUID);
+            return DateUtils.parseDicomDateTimeWithOffset(acquisitionDateTime);
+        }
+
+        if (StringUtils.isNotBlank(acquisitionDate) && StringUtils.isNotBlank(acquisitionTime) && StringUtils.isNotBlank(utcOffset)) {
+            logger.info("Using datetime with UTC offset(00080201) for study {}", studyInstanceUID);
+            return DateUtils.parseDicomDateTimeWithOffset(acquisitionDate + acquisitionTime + utcOffset);
+        }
+
+        if (StringUtils.isNotBlank(acquisitionDate) && StringUtils.isNotBlank(acquisitionTime)) {
+            logger.info("Using local datetime (no UTC offset) for study {}", studyInstanceUID);
+            return DateUtils.combineDicomDateTime(acquisitionDate, acquisitionTime);
+        }
+        return null;
     }
 
     private Map<String, Object> createDateCompletedExtension(Date studyDateTime) {

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImpl.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImpl.java
@@ -17,8 +17,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Arrays;
+import java.util.HashMap;
+
 import java.io.IOException;
-import java.util.*;
 
 @Service
 public class ImagingStudyServiceImpl implements ImagingStudyService {

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImpl.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImpl.java
@@ -4,43 +4,49 @@ import org.apache.commons.lang.StringUtils;
 import org.bahmni.module.pacsintegration.atomfeed.contract.fhir.FhirImagingStudy;
 import org.bahmni.module.pacsintegration.atomfeed.contract.fhir.JsonPatchOperation;
 import org.bahmni.module.pacsintegration.atomfeed.mappers.ImagingStudyMapper;
+import org.bahmni.module.pacsintegration.dto.DicomMetadataDTO;
 import org.bahmni.module.pacsintegration.model.ImagingStudyReference;
 import org.bahmni.module.pacsintegration.model.Order;
 import org.bahmni.module.pacsintegration.repository.ImagingStudyReferenceRepository;
-import org.bahmni.module.pacsintegration.repository.OrderRepository;
+import org.bahmni.module.pacsintegration.services.Dcm4CheeService;
 import org.bahmni.module.pacsintegration.services.ImagingStudyService;
 import org.bahmni.module.pacsintegration.services.OpenMRSService;
+import org.bahmni.module.pacsintegration.utils.DateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 @Service
 public class ImagingStudyServiceImpl implements ImagingStudyService {
-    
+
+    private static final String DATE_COMPLETION_EXTENSION_URL = "http://fhir.bahmni.org/ext/imaging-study/completion-date";
+
     private static final Logger logger = LoggerFactory.getLogger(ImagingStudyServiceImpl.class);
 
     @Autowired
     private OpenMRSService openMRSService;
-    
+
     @Autowired
     private ImagingStudyMapper imagingStudyMapper;
 
     @Autowired
     private ImagingStudyReferenceRepository imagingStudyReferenceRepository;
 
+    @Autowired
+    private Dcm4CheeService dcm4CheeService;
+
     @Override
     public String createImagingStudy(
             Order order,
-            String patientUuid, 
-            String locationUuid, 
+            String patientUuid,
+            String locationUuid,
             String studyInstanceUID,
             String description) throws IOException {
-        
+
         if (StringUtils.isBlank(studyInstanceUID)) {
             throw new IllegalArgumentException("StudyInstanceUID cannot be null or empty");
         }
@@ -52,7 +58,7 @@ public class ImagingStudyServiceImpl implements ImagingStudyService {
         if (StringUtils.isBlank(imagingStudyUuid)) {
             throw new IOException("Failed to create ImagingStudy - UUID not returned from OpenMRS");
         }
-        
+
         ImagingStudyReference imagingStudyReference = new ImagingStudyReference(
                 studyInstanceUID,
                 imagingStudyUuid,
@@ -81,12 +87,41 @@ public class ImagingStudyServiceImpl implements ImagingStudyService {
             throw new IOException("ImagingStudy UUID is null or empty for StudyInstanceUID: " + studyInstanceUID);
         }
 
+        DicomMetadataDTO[] metadataArray = dcm4CheeService.fetchStudyMetadata(studyInstanceUID);
+        Date studyDateTime = getStudyDateTime(studyInstanceUID, metadataArray);
+
         List<JsonPatchOperation> patchOperations = new ArrayList<>();
         patchOperations.add(new JsonPatchOperation("replace", "/status", "available"));
-        
+
+        if (studyDateTime != null) {
+            Map<String, Object> extension = createDateCompletedExtension(studyDateTime);
+            patchOperations.add(new JsonPatchOperation("add", "/extension", Arrays.asList(extension)));
+        }
+
         openMRSService.updateFhirImagingStudyStatus(imagingStudyUuid, patchOperations);
         
         logger.info("Successfully updated ImagingStudy status to 'available' for StudyInstanceUID: {} (UUID: {})", 
                 studyInstanceUID, imagingStudyUuid);
+    }
+
+    private static Date getStudyDateTime(String studyInstanceUID, DicomMetadataDTO[] metadataArray) throws IOException {
+        if (metadataArray == null || metadataArray.length == 0) {
+            return null;
+        }
+
+        DicomMetadataDTO metadata = metadataArray[0];
+
+        String acquisitionDate = metadata.getAcquisitionDate();
+        String acquisitionTime = metadata.getAcquisitionTime();
+
+        logger.info("Extracted acquisition date: {}, time: {}, for study {}", acquisitionDate, acquisitionTime, studyInstanceUID);
+        return DateUtils.combineDicomDateTime(acquisitionDate, acquisitionTime);
+    }
+
+    private Map<String, Object> createDateCompletedExtension(Date studyDateTime) {
+        Map<String, Object> extension = new HashMap<>();
+        extension.put("url", DATE_COMPLETION_EXTENSION_URL);
+        extension.put("valueDateTime", DateUtils.formatFhirDateTime(studyDateTime));
+        return extension;
     }
 }

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/utils/DateUtils.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/utils/DateUtils.java
@@ -1,0 +1,45 @@
+package org.bahmni.module.pacsintegration.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+
+public class DateUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(DateUtils.class);
+    
+    private static final String FHIR_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
+    private static final String DICOM_DATETIME_FORMAT = "yyyyMMddHHmmss";
+
+    private DateUtils() {}
+
+
+    public static String formatFhirDateTime(Date date) {
+        SimpleDateFormat fhirFormat = new SimpleDateFormat(FHIR_DATETIME_FORMAT);
+        return fhirFormat.format(date);
+    }
+
+
+    public static Date combineDicomDateTime(String dicomDate, String dicomTime) throws IOException {
+        try {
+            // Remove fractional seconds if present (e.g., 141836.123456 -> 141836)
+            String timePart = dicomTime;
+            if (timePart.contains(".")) {
+                timePart = timePart.substring(0, timePart.indexOf("."));
+            }
+
+            String dateTimeStr = dicomDate + timePart;
+            SimpleDateFormat dicomFormat = new SimpleDateFormat(DICOM_DATETIME_FORMAT);
+            dicomFormat.setLenient(false);
+            return dicomFormat.parse(dateTimeStr);
+        } catch (ParseException e) {
+            logger.error("Failed to parse DICOM date/time: date={}, time={}", dicomDate, dicomTime, e);
+            throw new IOException("Failed to parse DICOM date/time", e);
+        }
+    }
+}

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/utils/DateUtils.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/utils/DateUtils.java
@@ -23,6 +23,7 @@ public class DateUtils {
 
     public static String formatFhirDateTime(Date date) {
         SimpleDateFormat fhirFormat = new SimpleDateFormat(FHIR_DATETIME_FORMAT);
+        fhirFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
         return fhirFormat.format(date);
     }
 

--- a/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/utils/DateUtils.java
+++ b/pacs-integration-webapp/src/main/java/org/bahmni/module/pacsintegration/utils/DateUtils.java
@@ -1,12 +1,13 @@
 package org.bahmni.module.pacsintegration.utils;
 
+import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 
 public class DateUtils {
@@ -15,6 +16,7 @@ public class DateUtils {
     
     private static final String FHIR_DATETIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss";
     private static final String DICOM_DATETIME_FORMAT = "yyyyMMddHHmmss";
+    private static final String DICOM_DATETIME_FORMAT_WITH_OFFSET = "yyyyMMddHHmmssXX";
 
     private DateUtils() {}
 
@@ -25,7 +27,7 @@ public class DateUtils {
     }
 
 
-    public static Date combineDicomDateTime(String dicomDate, String dicomTime) throws IOException {
+    public static Date combineDicomDateTime(String dicomDate, String dicomTime) {
         try {
             // Remove fractional seconds if present (e.g., 141836.123456 -> 141836)
             String timePart = dicomTime;
@@ -39,7 +41,25 @@ public class DateUtils {
             return dicomFormat.parse(dateTimeStr);
         } catch (ParseException e) {
             logger.error("Failed to parse DICOM date/time: date={}, time={}", dicomDate, dicomTime, e);
-            throw new IOException("Failed to parse DICOM date/time", e);
         }
+        return null;
+    }
+
+    public static Date parseDicomDateTimeWithOffset(String dicomDateTime) {
+        try {
+            String cleaned = dicomDateTime.trim();
+            
+            // Remove fractional seconds if present (SimpleDateFormat has limits on fractional precision)
+            cleaned = cleaned.replaceFirst("\\.\\d+", "");
+
+            SimpleDateFormat formatWithOffset = new SimpleDateFormat(DICOM_DATETIME_FORMAT_WITH_OFFSET);
+            formatWithOffset.setTimeZone(TimeZone.getTimeZone("UTC"));
+            formatWithOffset.setLenient(false);
+            return formatWithOffset.parse(cleaned);
+            
+        } catch (ParseException e) {
+            logger.error("Failed to parse with offset : {}", dicomDateTime, e);
+        }
+        return null;
     }
 }

--- a/pacs-integration-webapp/src/main/resources/application.properties
+++ b/pacs-integration-webapp/src/main/resources/application.properties
@@ -18,3 +18,9 @@ enable.scheduling=true
 order.requested.location.attribute.name=REQUESTED_LOCATION
 
 create.imagingstudy.enabled=false
+
+# DCM4CHEE Configuration
+dcm4chee.base.url=http://dcm4chee5:8080
+dcm4chee.aet=DCM4CHEE
+dcm4chee.connection.timeout=10000
+dcm4chee.read.timeout=10000

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/client/Dcm4CheeConnectionDetailsTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/client/Dcm4CheeConnectionDetailsTest.java
@@ -1,0 +1,77 @@
+package org.bahmni.module.pacsintegration.client;
+
+import org.bahmni.webclients.ConnectionDetails;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+
+import static org.junit.Assert.*;
+
+public class Dcm4CheeConnectionDetailsTest {
+
+    private static final String TEST_BASE_URL = "http://localhost:8080/dcm4chee";
+    private static final int TEST_CONNECT_TIMEOUT = 5000;
+    private static final int TEST_READ_TIMEOUT = 30000;
+
+    @Before
+    public void setUp() throws Exception {
+        setStaticField("dcm4cheeBaseUrl", TEST_BASE_URL);
+        setStaticField("connectTimeoutInMilliseconds", TEST_CONNECT_TIMEOUT);
+        setStaticField("readTimeoutInMilliseconds", TEST_READ_TIMEOUT);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        setStaticField("dcm4cheeBaseUrl", null);
+        setStaticField("connectTimeoutInMilliseconds", 0);
+        setStaticField("readTimeoutInMilliseconds", 0);
+    }
+
+    @Test
+    public void shouldReturnConnectionDetailsWithCorrectAuthUrl() {
+        ConnectionDetails connectionDetails = Dcm4CheeConnectionDetails.get();
+
+        assertNotNull(connectionDetails);
+        assertEquals(TEST_BASE_URL, connectionDetails.getAuthUrl());
+    }
+
+    @Test
+    public void shouldReturnNewConnectionDetailsInstanceOnEachCall() {
+        ConnectionDetails connectionDetails1 = Dcm4CheeConnectionDetails.get();
+        ConnectionDetails connectionDetails2 = Dcm4CheeConnectionDetails.get();
+
+        assertNotNull(connectionDetails1);
+        assertNotNull(connectionDetails2);
+        assertNotSame(connectionDetails1, connectionDetails2);
+    }
+
+    @Test
+    public void shouldHandleNullBaseUrl() throws Exception {
+        setStaticField("dcm4cheeBaseUrl", null);
+
+        ConnectionDetails connectionDetails = Dcm4CheeConnectionDetails.get();
+
+        assertNotNull(connectionDetails);
+        assertNull(connectionDetails.getAuthUrl());
+    }
+
+    @Test
+    public void shouldHandleDifferentBaseUrls() throws Exception {
+        setStaticField("dcm4cheeBaseUrl", "http://server1.com");
+        ConnectionDetails cd1 = Dcm4CheeConnectionDetails.get();
+
+        setStaticField("dcm4cheeBaseUrl", "http://server2.com");
+        ConnectionDetails cd2 = Dcm4CheeConnectionDetails.get();
+
+        assertEquals("http://server1.com", cd1.getAuthUrl());
+        assertEquals("http://server2.com", cd2.getAuthUrl());
+    }
+
+    private void setStaticField(String fieldName, Object value) throws Exception {
+        Field field = Dcm4CheeConnectionDetails.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(null, value);
+    }
+}

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/client/HttpClientFactoryTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/client/HttpClientFactoryTest.java
@@ -1,0 +1,57 @@
+package org.bahmni.module.pacsintegration.client;
+
+import org.bahmni.webclients.ConnectionDetails;
+import org.bahmni.webclients.HttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(Dcm4CheeConnectionDetails.class)
+public class HttpClientFactoryTest {
+
+    private ConnectionDetails mockConnectionDetails;
+
+    @Before
+    public void setUp() {
+        mockConnectionDetails = mock(ConnectionDetails.class);
+        PowerMockito.mockStatic(Dcm4CheeConnectionDetails.class);
+    }
+
+    @Test
+    public void shouldReturnNonNullHttpClient() {
+        PowerMockito.when(Dcm4CheeConnectionDetails.get()).thenReturn(mockConnectionDetails);
+
+        HttpClient httpClient = HttpClientFactory.getDcm4CheeClient();
+
+        assertNotNull(httpClient);
+    }
+
+    @Test
+    public void shouldCreateHttpClientWithConnectionDetails() {
+        PowerMockito.when(Dcm4CheeConnectionDetails.get()).thenReturn(mockConnectionDetails);
+
+        HttpClient httpClient = HttpClientFactory.getDcm4CheeClient();
+
+        assertNotNull(httpClient);
+        PowerMockito.verifyStatic();
+    }
+
+    @Test
+    public void shouldReturnNewHttpClientInstanceOnEachCall() {
+        PowerMockito.when(Dcm4CheeConnectionDetails.get()).thenReturn(mockConnectionDetails);
+
+        HttpClient httpClient1 = HttpClientFactory.getDcm4CheeClient();
+        HttpClient httpClient2 = HttpClientFactory.getDcm4CheeClient();
+
+        assertNotNull(httpClient1);
+        assertNotNull(httpClient2);
+        assertNotSame(httpClient1, httpClient2);
+    }
+}

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/dto/DicomMetadataDTOTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/dto/DicomMetadataDTOTest.java
@@ -1,0 +1,320 @@
+package org.bahmni.module.pacsintegration.dto;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class DicomMetadataDTOTest {
+
+    @Test
+    public void shouldInitializeMetadataMapInConstructor() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+
+        assertNotNull(dto.getMetadata());
+        assertTrue(dto.getMetadata().isEmpty());
+    }
+
+    @Test
+    public void shouldAddDicomTagToMetadata() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{"20240115"});
+
+        dto.setDicomTag("00080022", field);
+
+        assertEquals(1, dto.getMetadata().size());
+        assertTrue(dto.getMetadata().containsKey("00080022"));
+        assertEquals(field, dto.getMetadata().get("00080022"));
+    }
+
+    @Test
+    public void shouldAddMultipleDicomTagsToMetadata() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field1 = new DicomMetadataDTO.DicomField();
+        field1.setValue(new Object[]{"20240115"});
+        DicomMetadataDTO.DicomField field2 = new DicomMetadataDTO.DicomField();
+        field2.setValue(new Object[]{"143045"});
+
+        dto.setDicomTag("00080022", field1);
+        dto.setDicomTag("00080032", field2);
+
+        assertEquals(2, dto.getMetadata().size());
+        assertTrue(dto.getMetadata().containsKey("00080022"));
+        assertTrue(dto.getMetadata().containsKey("00080032"));
+    }
+
+    @Test
+    public void shouldOverwriteExistingDicomTag() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field1 = new DicomMetadataDTO.DicomField();
+        field1.setValue(new Object[]{"20240115"});
+        DicomMetadataDTO.DicomField field2 = new DicomMetadataDTO.DicomField();
+        field2.setValue(new Object[]{"20240116"});
+
+        dto.setDicomTag("00080022", field1);
+        dto.setDicomTag("00080022", field2);
+
+        assertEquals(1, dto.getMetadata().size());
+        assertEquals(field2, dto.getMetadata().get("00080022"));
+    }
+
+    @Test
+    public void shouldReturnAcquisitionDateWhenTagExists() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{"20240115"});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATE_TAG, field);
+
+        String result = dto.getAcquisitionDate();
+
+        assertEquals("20240115", result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionDateTagDoesNotExist() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+
+        String result = dto.getAcquisitionDate();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionDateValueIsNull() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(null);
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATE_TAG, field);
+
+        String result = dto.getAcquisitionDate();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionDateValueIsEmpty() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATE_TAG, field);
+
+        String result = dto.getAcquisitionDate();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnFirstValueWhenAcquisitionDateHasMultipleValues() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{"20240115", "20240116", "20240117"});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATE_TAG, field);
+
+        String result = dto.getAcquisitionDate();
+
+        assertEquals("20240115", result);
+    }
+
+    @Test
+    public void shouldReturnAcquisitionTimeWhenTagExists() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{"143045"});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_TIME_TAG, field);
+
+        String result = dto.getAcquisitionTime();
+
+        assertEquals("143045", result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionTimeTagDoesNotExist() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+
+        String result = dto.getAcquisitionTime();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionTimeValueIsNull() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(null);
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_TIME_TAG, field);
+
+        String result = dto.getAcquisitionTime();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionTimeValueIsEmpty() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_TIME_TAG, field);
+
+        String result = dto.getAcquisitionTime();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnAcquisitionDateTimeWhenTagExists() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{"20240115143045+0530"});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATETIME_WITH_OFFSET_TAG, field);
+
+        String result = dto.getAcquisitionDateTime();
+
+        assertEquals("20240115143045+0530", result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionDateTimeTagDoesNotExist() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+
+        String result = dto.getAcquisitionDateTime();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionDateTimeValueIsNull() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(null);
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATETIME_WITH_OFFSET_TAG, field);
+
+        String result = dto.getAcquisitionDateTime();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenAcquisitionDateTimeValueIsEmpty() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATETIME_WITH_OFFSET_TAG, field);
+
+        String result = dto.getAcquisitionDateTime();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnTimezoneOffsetFromUTCWhenTagExists() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{"+0530"});
+        dto.setDicomTag(DicomMetadataDTO.TIMEZONE_OFFSET_FROM_UTC_TAG, field);
+
+        String result = dto.getTimezoneOffsetFromUTC();
+
+        assertEquals("+0530", result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenTimezoneOffsetFromUTCTagDoesNotExist() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+
+        String result = dto.getTimezoneOffsetFromUTC();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenTimezoneOffsetFromUTCValueIsNull() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(null);
+        dto.setDicomTag(DicomMetadataDTO.TIMEZONE_OFFSET_FROM_UTC_TAG, field);
+
+        String result = dto.getTimezoneOffsetFromUTC();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenTimezoneOffsetFromUTCValueIsEmpty() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{});
+        dto.setDicomTag(DicomMetadataDTO.TIMEZONE_OFFSET_FROM_UTC_TAG, field);
+
+        String result = dto.getTimezoneOffsetFromUTC();
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldReturnNullWhenMetadataIsNull() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        dto.setMetadata(null);
+
+        assertNull(dto.getAcquisitionDate());
+        assertNull(dto.getAcquisitionTime());
+        assertNull(dto.getAcquisitionDateTime());
+        assertNull(dto.getTimezoneOffsetFromUTC());
+    }
+
+    @Test
+    public void shouldConvertValueToStringUsingToString() {
+        DicomMetadataDTO dto = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{12345});
+        dto.setDicomTag(DicomMetadataDTO.AQUISITION_DATE_TAG, field);
+
+        String result = dto.getAcquisitionDate();
+
+        assertEquals("12345", result);
+    }
+
+    // Tests for DicomField inner class
+    @Test
+    public void shouldSetAndGetVrInDicomField() {
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setVr("DA");
+
+        assertEquals("DA", field.getVr());
+    }
+
+    @Test
+    public void shouldSetAndGetValueInDicomField() {
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        Object[] values = new Object[]{"20240115"};
+        field.setValue(values);
+
+        assertArrayEquals(values, field.getValue());
+    }
+
+    @Test
+    public void shouldInitializeDicomFieldWithDefaultConstructor() {
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+
+        assertNull(field.getVr());
+        assertNull(field.getValue());
+    }
+
+    @Test
+    public void shouldHandleComplexDicomFieldWithMultipleProperties() {
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setVr("DT");
+        field.setValue(new Object[]{"20240115143045.123456+0530"});
+
+        assertEquals("DT", field.getVr());
+        assertEquals(1, field.getValue().length);
+        assertEquals("20240115143045.123456+0530", field.getValue()[0]);
+    }
+
+    @Test
+    public void shouldVerifyDicomTagConstants() {
+        assertEquals("00080022", DicomMetadataDTO.AQUISITION_DATE_TAG);
+        assertEquals("00080032", DicomMetadataDTO.AQUISITION_TIME_TAG);
+        assertEquals("0008002A", DicomMetadataDTO.AQUISITION_DATETIME_WITH_OFFSET_TAG);
+        assertEquals("00080201", DicomMetadataDTO.TIMEZONE_OFFSET_FROM_UTC_TAG);
+    }
+}

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/Dcm4CheeServiceTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/Dcm4CheeServiceTest.java
@@ -1,0 +1,168 @@
+package org.bahmni.module.pacsintegration.services;
+
+import org.bahmni.module.pacsintegration.client.HttpClientFactory;
+import org.bahmni.module.pacsintegration.dto.DicomMetadataDTO;
+import org.bahmni.webclients.HttpClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+@PrepareForTest(HttpClientFactory.class)
+@RunWith(PowerMockRunner.class)
+public class Dcm4CheeServiceTest {
+
+    @Mock
+    private HttpClient webClient;
+
+    private Dcm4CheeService dcm4CheeService;
+
+    private static final String DCM4CHEE_BASE_URL = "http://localhost:8080";
+    private static final String DCM4CHEE_AET = "DCM4CHEE";
+    private static final String STUDY_INSTANCE_UID = "1.2.3.4.5.6.7.8.9";
+
+    @Before
+    public void setUp() throws Exception {
+        dcm4CheeService = new Dcm4CheeService();
+        ReflectionTestUtils.setField(dcm4CheeService, "dcm4cheeBaseUrl", DCM4CHEE_BASE_URL);
+        ReflectionTestUtils.setField(dcm4CheeService, "dcm4cheeAet", DCM4CHEE_AET);
+    }
+
+    @Test
+    public void shouldFetchStudyMetadataSuccessfully() throws Exception {
+        PowerMockito.mockStatic(HttpClientFactory.class);
+        when(HttpClientFactory.getDcm4CheeClient()).thenReturn(webClient);
+
+        DicomMetadataDTO[] expectedMetadata = new DicomMetadataDTO[2];
+        expectedMetadata[0] = new DicomMetadataDTO();
+        expectedMetadata[1] = new DicomMetadataDTO();
+
+        String expectedUrl = String.format("%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata",
+                DCM4CHEE_BASE_URL, DCM4CHEE_AET, STUDY_INSTANCE_UID);
+
+        when(webClient.get(expectedUrl, DicomMetadataDTO[].class)).thenReturn(expectedMetadata);
+
+        DicomMetadataDTO[] result = dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID);
+
+        assertNotNull(result);
+        assertEquals(2, result.length);
+        assertEquals(expectedMetadata, result);
+        verify(webClient).get(expectedUrl, DicomMetadataDTO[].class);
+    }
+
+    @Test
+    public void shouldReturnEmptyArrayWhenNoMetadataFound() throws Exception {
+        PowerMockito.mockStatic(HttpClientFactory.class);
+        when(HttpClientFactory.getDcm4CheeClient()).thenReturn(webClient);
+
+        DicomMetadataDTO[] expectedMetadata = new DicomMetadataDTO[0];
+        String expectedUrl = String.format("%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata",
+                DCM4CHEE_BASE_URL, DCM4CHEE_AET, STUDY_INSTANCE_UID);
+
+        when(webClient.get(expectedUrl, DicomMetadataDTO[].class)).thenReturn(expectedMetadata);
+
+        DicomMetadataDTO[] result = dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID);
+
+        assertNotNull(result);
+        assertEquals(0, result.length);
+        verify(webClient).get(expectedUrl, DicomMetadataDTO[].class);
+    }
+
+    @Test(expected = IOException.class)
+    public void shouldThrowIOExceptionWhenFetchFails() throws Exception {
+        PowerMockito.mockStatic(HttpClientFactory.class);
+        when(HttpClientFactory.getDcm4CheeClient()).thenReturn(webClient);
+
+        String expectedUrl = String.format("%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata",
+                DCM4CHEE_BASE_URL, DCM4CHEE_AET, STUDY_INSTANCE_UID);
+
+        when(webClient.get(expectedUrl, DicomMetadataDTO[].class))
+                .thenThrow(new IOException("Network error"));
+
+        dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID);
+    }
+
+    @Test
+    public void shouldBuildCorrectMetadataUrl() throws Exception {
+        PowerMockito.mockStatic(HttpClientFactory.class);
+        when(HttpClientFactory.getDcm4CheeClient()).thenReturn(webClient);
+
+        DicomMetadataDTO[] expectedMetadata = new DicomMetadataDTO[0];
+        String customStudyUID = "9.8.7.6.5.4.3.2.1";
+        String expectedUrl = String.format("%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata",
+                DCM4CHEE_BASE_URL, DCM4CHEE_AET, customStudyUID);
+
+        when(webClient.get(expectedUrl, DicomMetadataDTO[].class)).thenReturn(expectedMetadata);
+
+        dcm4CheeService.fetchStudyMetadata(customStudyUID);
+
+        verify(webClient).get(expectedUrl, DicomMetadataDTO[].class);
+    }
+
+    @Test
+    public void shouldBuildUrlWithDifferentBaseUrlAndAet() throws Exception {
+        PowerMockito.mockStatic(HttpClientFactory.class);
+        when(HttpClientFactory.getDcm4CheeClient()).thenReturn(webClient);
+
+        String customBaseUrl = "https://pacs.example.com";
+        String customAet = "CUSTOM_AET";
+        ReflectionTestUtils.setField(dcm4CheeService, "dcm4cheeBaseUrl", customBaseUrl);
+        ReflectionTestUtils.setField(dcm4CheeService, "dcm4cheeAet", customAet);
+
+        DicomMetadataDTO[] expectedMetadata = new DicomMetadataDTO[0];
+        String expectedUrl = String.format("%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata",
+                customBaseUrl, customAet, STUDY_INSTANCE_UID);
+
+        when(webClient.get(expectedUrl, DicomMetadataDTO[].class)).thenReturn(expectedMetadata);
+
+        dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID);
+
+        verify(webClient).get(expectedUrl, DicomMetadataDTO[].class);
+    }
+
+    @Test
+    public void shouldHandleNullResponseFromWebClient() throws Exception {
+        PowerMockito.mockStatic(HttpClientFactory.class);
+        when(HttpClientFactory.getDcm4CheeClient()).thenReturn(webClient);
+
+        String expectedUrl = String.format("%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata",
+                DCM4CHEE_BASE_URL, DCM4CHEE_AET, STUDY_INSTANCE_UID);
+
+        when(webClient.get(expectedUrl, DicomMetadataDTO[].class)).thenReturn(null);
+
+        DicomMetadataDTO[] result = dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID);
+
+        assertNull(result);
+        verify(webClient).get(expectedUrl, DicomMetadataDTO[].class);
+    }
+
+    @Test
+    public void shouldHandleStudyUIDWithSpecialCharacters() throws Exception {
+        PowerMockito.mockStatic(HttpClientFactory.class);
+        when(HttpClientFactory.getDcm4CheeClient()).thenReturn(webClient);
+
+        String studyUIDWithSpecialChars = "1.2.840.10008.5.1.4.1.1.1.1";
+        DicomMetadataDTO[] expectedMetadata = new DicomMetadataDTO[1];
+        expectedMetadata[0] = new DicomMetadataDTO();
+
+        String expectedUrl = String.format("%s/dcm4chee-arc/aets/%s/rs/studies/%s/metadata",
+                DCM4CHEE_BASE_URL, DCM4CHEE_AET, studyUIDWithSpecialChars);
+
+        when(webClient.get(expectedUrl, DicomMetadataDTO[].class)).thenReturn(expectedMetadata);
+
+        DicomMetadataDTO[] result = dcm4CheeService.fetchStudyMetadata(studyUIDWithSpecialChars);
+
+        assertNotNull(result);
+        assertEquals(1, result.length);
+        verify(webClient).get(expectedUrl, DicomMetadataDTO[].class);
+    }
+}

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/Dcm4CheeServiceTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/Dcm4CheeServiceTest.java
@@ -165,4 +165,13 @@ public class Dcm4CheeServiceTest {
         assertEquals(1, result.length);
         verify(webClient).get(expectedUrl, DicomMetadataDTO[].class);
     }
+
+    @Test
+    public void shouldReturnNullWhenDcm4cheeBaseUrlIsNull() throws Exception {
+        ReflectionTestUtils.setField(dcm4CheeService, "dcm4cheeBaseUrl", null);
+
+        DicomMetadataDTO[] result = dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID);
+
+        assertNull(result);
+    }
 }

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImplTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImplTest.java
@@ -1,18 +1,24 @@
 package org.bahmni.module.pacsintegration.services.impl;
 
 import org.bahmni.module.pacsintegration.atomfeed.contract.fhir.FhirImagingStudy;
+import org.bahmni.module.pacsintegration.atomfeed.contract.fhir.JsonPatchOperation;
 import org.bahmni.module.pacsintegration.atomfeed.mappers.ImagingStudyMapper;
+import org.bahmni.module.pacsintegration.dto.DicomMetadataDTO;
 import org.bahmni.module.pacsintegration.model.ImagingStudyReference;
 import org.bahmni.module.pacsintegration.model.Order;
 import org.bahmni.module.pacsintegration.repository.ImagingStudyReferenceRepository;
+import org.bahmni.module.pacsintegration.services.Dcm4CheeService;
 import org.bahmni.module.pacsintegration.services.OpenMRSService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -24,6 +30,9 @@ public class ImagingStudyServiceImplTest  {
 
     @Mock
     private OpenMRSService openMRSService;
+
+    @Mock
+    private Dcm4CheeService dcm4CheeService;
 
     @Mock
     private ImagingStudyMapper imagingStudyMapper;
@@ -201,5 +210,241 @@ public class ImagingStudyServiceImplTest  {
                 .updateFhirImagingStudyStatus(eq(imagingStudyUuid), anyList());
 
         imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+    }
+
+    @Test
+    public void shouldFetchMetadataFromDcm4CheeService() throws Exception {
+        String imagingStudyUuid = "imaging-study-uuid-123";
+        ImagingStudyReference reference = new ImagingStudyReference();
+        reference.setImagingStudyUuid(imagingStudyUuid);
+        
+        DicomMetadataDTO metadata = createMetadataWithAcquisitionDateTime("20240115143000+0530");
+        DicomMetadataDTO[] metadataArray = new DicomMetadataDTO[]{metadata};
+        
+        when(imagingStudyReferenceRepository.findByStudyInstanceUid(STUDY_INSTANCE_UID)).thenReturn(reference);
+        when(dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID)).thenReturn(metadataArray);
+
+        imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+
+        verify(dcm4CheeService).fetchStudyMetadata(STUDY_INSTANCE_UID);
+    }
+
+    @Test
+    public void shouldUpdateWithDateExtensionWhenAcquisitionDateTimePresent() throws Exception {
+        String imagingStudyUuid = "imaging-study-uuid-123";
+        ImagingStudyReference reference = new ImagingStudyReference();
+        reference.setImagingStudyUuid(imagingStudyUuid);
+        
+        DicomMetadataDTO metadata = createMetadataWithAcquisitionDateTime("20240115143000+0530");
+        DicomMetadataDTO[] metadataArray = new DicomMetadataDTO[]{metadata};
+        
+        when(imagingStudyReferenceRepository.findByStudyInstanceUid(STUDY_INSTANCE_UID)).thenReturn(reference);
+        when(dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID)).thenReturn(metadataArray);
+
+        imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+
+        ArgumentCaptor<List> patchOpsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(openMRSService).updateFhirImagingStudyStatus(eq(imagingStudyUuid), patchOpsCaptor.capture());
+        
+        List<JsonPatchOperation> patchOperations = patchOpsCaptor.getValue();
+        assertEquals(2, patchOperations.size());
+        
+        JsonPatchOperation statusOp = patchOperations.get(0);
+        assertEquals("replace", statusOp.getOp());
+        assertEquals("/status", statusOp.getPath());
+        assertEquals("available", statusOp.getValue());
+        
+        JsonPatchOperation extensionOp = patchOperations.get(1);
+        assertEquals("add", extensionOp.getOp());
+        assertEquals("/extension", extensionOp.getPath());
+        assertNotNull(extensionOp.getValue());
+    }
+
+    @Test
+    public void shouldUpdateWithDateExtensionWhenDateTimeAndOffsetPresent() throws Exception {
+        String imagingStudyUuid = "imaging-study-uuid-123";
+        ImagingStudyReference reference = new ImagingStudyReference();
+        reference.setImagingStudyUuid(imagingStudyUuid);
+        
+        DicomMetadataDTO metadata = createMetadataWithDateTimeAndOffset("20240115", "143000", "+0530");
+        DicomMetadataDTO[] metadataArray = new DicomMetadataDTO[]{metadata};
+        
+        when(imagingStudyReferenceRepository.findByStudyInstanceUid(STUDY_INSTANCE_UID)).thenReturn(reference);
+        when(dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID)).thenReturn(metadataArray);
+
+        imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+
+        ArgumentCaptor<List> patchOpsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(openMRSService).updateFhirImagingStudyStatus(eq(imagingStudyUuid), patchOpsCaptor.capture());
+        
+        List<JsonPatchOperation> patchOperations = patchOpsCaptor.getValue();
+        assertEquals(2, patchOperations.size());
+        
+        JsonPatchOperation extensionOp = patchOperations.get(1);
+        assertEquals("add", extensionOp.getOp());
+        assertEquals("/extension", extensionOp.getPath());
+        
+        List<Map<String, Object>> extensionList = (List<Map<String, Object>>) extensionOp.getValue();
+        assertNotNull(extensionList);
+        assertEquals(1, extensionList.size());
+        
+        Map<String, Object> extension = extensionList.get(0);
+        assertEquals("http://fhir.bahmni.org/ext/imaging-study/completion-date", extension.get("url"));
+        assertNotNull(extension.get("valueDateTime"));
+    }
+
+    @Test
+    public void shouldUpdateWithDateExtensionWhenDateAndTimePresent() throws Exception {
+        String imagingStudyUuid = "imaging-study-uuid-123";
+        ImagingStudyReference reference = new ImagingStudyReference();
+        reference.setImagingStudyUuid(imagingStudyUuid);
+        
+        DicomMetadataDTO metadata = createMetadataWithDateAndTime("20240115", "143000");
+        DicomMetadataDTO[] metadataArray = new DicomMetadataDTO[]{metadata};
+        
+        when(imagingStudyReferenceRepository.findByStudyInstanceUid(STUDY_INSTANCE_UID)).thenReturn(reference);
+        when(dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID)).thenReturn(metadataArray);
+
+        imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+
+        ArgumentCaptor<List> patchOpsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(openMRSService).updateFhirImagingStudyStatus(eq(imagingStudyUuid), patchOpsCaptor.capture());
+        
+        List<JsonPatchOperation> patchOperations = patchOpsCaptor.getValue();
+        assertEquals(2, patchOperations.size());
+        
+        JsonPatchOperation extensionOp = patchOperations.get(1);
+        assertEquals("add", extensionOp.getOp());
+        assertEquals("/extension", extensionOp.getPath());
+        assertNotNull(extensionOp.getValue());
+    }
+
+    @Test
+    public void shouldUpdateWithoutDateExtensionWhenMetadataIsNull() throws Exception {
+        String imagingStudyUuid = "imaging-study-uuid-123";
+        ImagingStudyReference reference = new ImagingStudyReference();
+        reference.setImagingStudyUuid(imagingStudyUuid);
+        
+        when(imagingStudyReferenceRepository.findByStudyInstanceUid(STUDY_INSTANCE_UID)).thenReturn(reference);
+        when(dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID)).thenReturn(null);
+
+        imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+
+        ArgumentCaptor<List> patchOpsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(openMRSService).updateFhirImagingStudyStatus(eq(imagingStudyUuid), patchOpsCaptor.capture());
+        
+        List<JsonPatchOperation> patchOperations = patchOpsCaptor.getValue();
+        assertEquals(1, patchOperations.size());
+        
+        JsonPatchOperation statusOp = patchOperations.get(0);
+        assertEquals("replace", statusOp.getOp());
+        assertEquals("/status", statusOp.getPath());
+        assertEquals("available", statusOp.getValue());
+    }
+
+    @Test
+    public void shouldUpdateWithoutDateExtensionWhenMetadataIsEmpty() throws Exception {
+        String imagingStudyUuid = "imaging-study-uuid-123";
+        ImagingStudyReference reference = new ImagingStudyReference();
+        reference.setImagingStudyUuid(imagingStudyUuid);
+        
+        DicomMetadataDTO[] metadataArray = new DicomMetadataDTO[0];
+        
+        when(imagingStudyReferenceRepository.findByStudyInstanceUid(STUDY_INSTANCE_UID)).thenReturn(reference);
+        when(dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID)).thenReturn(metadataArray);
+
+        imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+
+        ArgumentCaptor<List> patchOpsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(openMRSService).updateFhirImagingStudyStatus(eq(imagingStudyUuid), patchOpsCaptor.capture());
+        
+        List<JsonPatchOperation> patchOperations = patchOpsCaptor.getValue();
+        assertEquals(1, patchOperations.size());
+        
+        JsonPatchOperation statusOp = patchOperations.get(0);
+        assertEquals("replace", statusOp.getOp());
+        assertEquals("/status", statusOp.getPath());
+        assertEquals("available", statusOp.getValue());
+    }
+
+    @Test
+    public void shouldVerifyPatchOperationsContainCorrectDateExtension() throws Exception {
+        String imagingStudyUuid = "imaging-study-uuid-123";
+        ImagingStudyReference reference = new ImagingStudyReference();
+        reference.setImagingStudyUuid(imagingStudyUuid);
+        
+        DicomMetadataDTO metadata = createMetadataWithAcquisitionDateTime("20240115143000+0530");
+        DicomMetadataDTO[] metadataArray = new DicomMetadataDTO[]{metadata};
+        
+        when(imagingStudyReferenceRepository.findByStudyInstanceUid(STUDY_INSTANCE_UID)).thenReturn(reference);
+        when(dcm4CheeService.fetchStudyMetadata(STUDY_INSTANCE_UID)).thenReturn(metadataArray);
+
+        imagingStudyService.updateImagingStudyAsAvailable(STUDY_INSTANCE_UID);
+
+        ArgumentCaptor<List> patchOpsCaptor = ArgumentCaptor.forClass(List.class);
+        verify(openMRSService).updateFhirImagingStudyStatus(eq(imagingStudyUuid), patchOpsCaptor.capture());
+        
+        List<JsonPatchOperation> patchOperations = patchOpsCaptor.getValue();
+        assertEquals(2, patchOperations.size());
+        
+        JsonPatchOperation statusOp = patchOperations.get(0);
+        assertEquals("replace", statusOp.getOp());
+        assertEquals("/status", statusOp.getPath());
+        assertEquals("available", statusOp.getValue());
+        
+        JsonPatchOperation extensionOp = patchOperations.get(1);
+        assertEquals("add", extensionOp.getOp());
+        assertEquals("/extension", extensionOp.getPath());
+        
+        List<Map<String, Object>> extensionList = (List<Map<String, Object>>) extensionOp.getValue();
+        assertNotNull(extensionList);
+        assertEquals(1, extensionList.size());
+        
+        Map<String, Object> extension = extensionList.get(0);
+        assertEquals("http://fhir.bahmni.org/ext/imaging-study/completion-date", extension.get("url"));
+        assertNotNull(extension.get("valueDateTime"));
+        String valueDateTime = (String) extension.get("valueDateTime");
+        assertEquals("2024-01-15T14:30:00", valueDateTime);
+    }
+
+    // Helper methods to create metadata DTOs
+    private DicomMetadataDTO createMetadataWithAcquisitionDateTime(String acquisitionDateTime) {
+        DicomMetadataDTO metadata = new DicomMetadataDTO();
+        DicomMetadataDTO.DicomField field = new DicomMetadataDTO.DicomField();
+        field.setValue(new Object[]{acquisitionDateTime});
+        metadata.setDicomTag(DicomMetadataDTO.AQUISITION_DATETIME_WITH_OFFSET_TAG, field);
+        return metadata;
+    }
+
+    private DicomMetadataDTO createMetadataWithDateTimeAndOffset(String date, String time, String offset) {
+        DicomMetadataDTO metadata = new DicomMetadataDTO();
+        
+        DicomMetadataDTO.DicomField dateField = new DicomMetadataDTO.DicomField();
+        dateField.setValue(new Object[]{date});
+        metadata.setDicomTag(DicomMetadataDTO.AQUISITION_DATE_TAG, dateField);
+        
+        DicomMetadataDTO.DicomField timeField = new DicomMetadataDTO.DicomField();
+        timeField.setValue(new Object[]{time});
+        metadata.setDicomTag(DicomMetadataDTO.AQUISITION_TIME_TAG, timeField);
+        
+        DicomMetadataDTO.DicomField offsetField = new DicomMetadataDTO.DicomField();
+        offsetField.setValue(new Object[]{offset});
+        metadata.setDicomTag(DicomMetadataDTO.TIMEZONE_OFFSET_FROM_UTC_TAG, offsetField);
+        
+        return metadata;
+    }
+
+    private DicomMetadataDTO createMetadataWithDateAndTime(String date, String time) {
+        DicomMetadataDTO metadata = new DicomMetadataDTO();
+        
+        DicomMetadataDTO.DicomField dateField = new DicomMetadataDTO.DicomField();
+        dateField.setValue(new Object[]{date});
+        metadata.setDicomTag(DicomMetadataDTO.AQUISITION_DATE_TAG, dateField);
+        
+        DicomMetadataDTO.DicomField timeField = new DicomMetadataDTO.DicomField();
+        timeField.setValue(new Object[]{time});
+        metadata.setDicomTag(DicomMetadataDTO.AQUISITION_TIME_TAG, timeField);
+        
+        return metadata;
     }
 }

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImplTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/services/impl/ImagingStudyServiceImplTest.java
@@ -404,7 +404,7 @@ public class ImagingStudyServiceImplTest  {
         assertEquals("http://fhir.bahmni.org/ext/imaging-study/completion-date", extension.get("url"));
         assertNotNull(extension.get("valueDateTime"));
         String valueDateTime = (String) extension.get("valueDateTime");
-        assertEquals("2024-01-15T14:30:00", valueDateTime);
+        assertEquals("2024-01-15T09:00:00", valueDateTime);
     }
 
     // Helper methods to create metadata DTOs

--- a/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/utils/DateUtilsTest.java
+++ b/pacs-integration-webapp/src/test/java/org/bahmni/module/pacsintegration/utils/DateUtilsTest.java
@@ -1,0 +1,164 @@
+package org.bahmni.module.pacsintegration.utils;
+
+import org.junit.Test;
+import java.util.Calendar;
+import java.util.Date;
+import static org.junit.Assert.*;
+
+public class DateUtilsTest {
+
+    @Test
+    public void shouldFormatDateToFhirDateTime() {
+        Calendar calendar = Calendar.getInstance();
+        calendar.set(2024, Calendar.JANUARY, 15, 14, 30, 45);
+        calendar.set(Calendar.MILLISECOND, 0);
+        Date date = calendar.getTime();
+
+        String result = DateUtils.formatFhirDateTime(date);
+
+        assertNotNull(result);
+        assertTrue(result.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"));
+        assertTrue(result.contains("2024-01-15T"));
+    }
+
+    @Test
+    public void shouldFormatEpochDateToFhirDateTime() {
+        Date epochDate = new Date(0);
+
+        String result = DateUtils.formatFhirDateTime(epochDate);
+
+        assertNotNull(result);
+        assertTrue(result.matches("\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}"));
+    }
+
+    @Test
+    public void shouldCombineDicomDateAndTime() {
+        String dicomDate = "20240115";
+        String dicomTime = "143045";
+
+        Date result = DateUtils.combineDicomDateTime(dicomDate, dicomTime);
+
+        assertNotNull(result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(result);
+        assertEquals(2024, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.JANUARY, calendar.get(Calendar.MONTH));
+        assertEquals(15, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(14, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(30, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
+    }
+
+    @Test
+    public void shouldCombineDicomDateAndTimeWithFractionalSeconds() {
+        String dicomDate = "20240115";
+        String dicomTime = "143045.123456";
+
+        Date result = DateUtils.combineDicomDateTime(dicomDate, dicomTime);
+
+        assertNotNull(result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(result);
+        assertEquals(2024, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.JANUARY, calendar.get(Calendar.MONTH));
+        assertEquals(15, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(14, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(30, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
+    }
+
+    @Test
+    public void shouldReturnNullWhenDicomDateTimeIsInvalidFormat() {
+        String dicomDate = "invalid";
+        String dicomTime = "143045";
+
+        Date result = DateUtils.combineDicomDateTime(dicomDate, dicomTime);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void shouldParseDicomDateTimeWithPositiveOffset() {
+        String dicomDateTime = "20240115143045+0530";
+
+        Date result = DateUtils.parseDicomDateTimeWithOffset(dicomDateTime);
+
+        assertNotNull(result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        calendar.setTime(result);
+        
+        assertEquals(2024, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.JANUARY, calendar.get(Calendar.MONTH));
+        assertEquals(15, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(9, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(0, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
+    }
+
+    @Test
+    public void shouldParseDicomDateTimeWithNegativeOffset() {
+        String dicomDateTime = "20240115143045-0500";
+
+        Date result = DateUtils.parseDicomDateTimeWithOffset(dicomDateTime);
+
+        assertNotNull(result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        calendar.setTime(result);
+        
+        assertEquals(2024, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.JANUARY, calendar.get(Calendar.MONTH));
+        assertEquals(15, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(19, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(30, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
+    }
+
+    @Test
+    public void shouldParseDicomDateTimeWithZeroOffset() {
+        String dicomDateTime = "20240115143045+0000";
+
+        Date result = DateUtils.parseDicomDateTimeWithOffset(dicomDateTime);
+
+        assertNotNull(result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        calendar.setTime(result);
+
+        assertEquals(2024, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.JANUARY, calendar.get(Calendar.MONTH));
+        assertEquals(15, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(14, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(30, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
+    }
+
+    @Test
+    public void shouldParseDicomDateTimeWithOffsetAndFractionalSeconds() {
+        String dicomDateTime = "20240115143045.123456+0530";
+
+        Date result = DateUtils.parseDicomDateTimeWithOffset(dicomDateTime);
+
+        assertNotNull(result);
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTimeZone(java.util.TimeZone.getTimeZone("UTC"));
+        calendar.setTime(result);
+
+        assertEquals(2024, calendar.get(Calendar.YEAR));
+        assertEquals(Calendar.JANUARY, calendar.get(Calendar.MONTH));
+        assertEquals(15, calendar.get(Calendar.DAY_OF_MONTH));
+        assertEquals(9, calendar.get(Calendar.HOUR_OF_DAY));
+        assertEquals(0, calendar.get(Calendar.MINUTE));
+        assertEquals(45, calendar.get(Calendar.SECOND));
+    }
+
+    @Test
+    public void shouldReturnNullWhenDicomDateTimeWithOffsetIsInvalidFormat() {
+        String dicomDateTime = "invalid-datetime";
+
+        Date result = DateUtils.parseDicomDateTimeWithOffset(dicomDateTime);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
## Overview : [BAH-4661](https://bahmni.atlassian.net/browse/BAH-4661)

This PR enhances the PACS integration by updating the ImagingStudy completion datetime with the actual study acquisition datetime fetched from DCM4CHEE DICOM metadata, including proper handling of timezone offsets.

## Changes Made


### 🆕 New Components

__Configuration:__

- Added DCM4CHEE configuration properties:

  - `dcm4chee.base.url` (DCM4CHEE_BASE_URL env variable)
  - `dcm4chee.aet` (default: DCM4CHEE)
  - `dcm4chee.connection.timeout` (default: 10000ms)
  - `dcm4chee.read.timeout` (default: 10000ms)


### 🔄 Modified Components

__`ImagingStudyServiceImpl`:__

- Enhanced `updateImagingStudyAsAvailable()` to:

  - Fetch DICOM metadata from DCM4CHEE
  - Extract acquisition datetime from metadata (with fallback logic)
  - Add FHIR extension for completion date
  - Update ImagingStudy with both status and completion datetime


### 🔑 Key Features

1. __Timezone Support__: Properly handles DICOM datetime with timezone offsets (e.g., +0530, -0500)

2. __Fallback Logic__: Tries multiple DICOM tags to extract acquisition datetime:

   - Primary: Acquisition DateTime with Offset (0008002A)
   - Fallback 1: Acquisition Date + Time + Timezone Offset
   - Fallback 2: Acquisition Date + Time (local time)

3. __FHIR Compliance__: Adds completion date as FHIR extension following the URL pattern: `http://fhir.bahmni.org/ext/imaging-study/completion-date`

4. __Error Handling__: Gracefully handles missing or invalid metadata

### 🎯 Technical Details

- Uses JSON PATCH operations to update ImagingStudy resource
- Converts DICOM datetime formats to FHIR-compliant ISO 8601 format
- Supports fractional seconds in DICOM time values
- Thread-safe date parsing using SimpleDateFormat with proper synchronization


[BAH-4661]: https://bahmni.atlassian.net/browse/BAH-4661?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ